### PR TITLE
responsive title font size

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -26,3 +26,10 @@
 html[data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }
+
+
+@media screen and (max-width: 440px) {
+  h1.hero__title {
+    font-size: 2rem;
+  }
+}


### PR DESCRIPTION
"Chia Documentation" on home wasn't responsive, now it is