### PR TITLE
Update docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -22,7 +22,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/nightOwl');
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/Chia-Network/chia-docs',
+          editUrl: 'https://github.com/Chia-Network/chia-docs/blob/main/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
fix edit URL, will bring to rendered markdown / source code page, or use `https://github.com/Chia-Network/chia-docs/edit/main/` instead to bring directly to edit page in GitHub. Prompts people to fork but doesn't show rendered markdown immediately