### PR TITLE
Updated attack %

### DIFF
--- a/docs/02architecture/p2p-system.md
+++ b/docs/02architecture/p2p-system.md
@@ -72,7 +72,7 @@ Timelords do not directly earn rewards. Furthermore, only the fastest timelord o
 
 If someone controls the fastest timelord in the world, it doesn't give them much of an advantage at winning rewards. However, they could potentially orphan or censor other farmers, depending on how much faster their timelord is.
 
-Furthermore, an attacker with a significantly faster timelord than anyone else could potentially run a 51% attack against the network with less than 51% of the space. For security purposes, it is very important to maintain open designs of VDF hardware.
+Furthermore, an attacker with a significantly faster timelord than anyone else could potentially run a long-range attack against the network with less than 42.6% of the total netspace. For security purposes, it is very important to maintain open designs of VDF hardware.
 
   >You can learn about potential attacks against Chia's network in [Section 3.14](/docs/03consensus/attacks_and_countermeasures "Section 3.14: Attacks and Countermeasures").
 

--- a/docs/03consensus/analysis.md
+++ b/docs/03consensus/analysis.md
@@ -7,7 +7,7 @@ sidebar_position: 15
 ## Safety
 The safety of Chia's consensus is similar to that of other Nakamoto consensus algorithms like Bitcoin. There is no guaranteed finality, but the more confirmations a transaction has, the safer it is.
 
-A transaction needs a certain number of confirmations for a receiver to assume that it cannot be re-orged, under the < 46% (* vdf advantage) colluding assumption. Since farmers can theoretically sign multiple blocks at the same height, more _confirmations_ should be used in Chia than in Bitcoin. However, Chia doesn't require anywhere near as much _clock time_ as Bitcoin for a transaction to be considered safe.
+A transaction needs a certain number of confirmations for a receiver to assume that it cannot be re-orged, under the < 42.6% (* vdf advantage) colluding assumption. Since farmers can theoretically sign multiple blocks at the same height, more _confirmations_ should be used in Chia than in Bitcoin. However, Chia doesn't require anywhere near as much _clock time_ as Bitcoin for a transaction to be considered safe.
 
 In Chia, there are two main reasons to wait for a certain number of confirmations:
 1. To be confident there won't be a chain re-org. As discussed in [Section 3.10](/docs/03consensus/foliage "Section 3.10: Foliage"), a small re-org is a natural occurrence in blockchains, though rare in Chia.
@@ -37,7 +37,7 @@ Of course, in the event of a long-term network split, the effects are that one c
 + (+) Hopefully more decentralized. (Analysis in mainnet's first year shows this to be the case.)
 + (+) Easy merge farming. Other cryptocurrencies can use the same format, and everyone can share the space (assuming their farming computers have sufficient disk space and memory). (Note that the blockchain with the largest netspace will probably be the only secure one, since the farmers can attack smaller ones. This is especially true of blockchains with less than 50% of the top chain's netspace -- the remaining farmers who have not joined the smaller chain could collude to join, and attack, that chain.)
 + (+) Minimum energy used, since only a few nodes run VDFs, and these are not parallelized. Very low marginal cost to farm.
-+ (+) More consistent transaction block times (targeted average is one per 46.875 seconds, as discussed in [Section 3.10](/docs/03consensus/foliage "Section 3.10: Foliage")).
++ (+) More consistent transaction block times (targeted average is one per 52 seconds, as discussed in [Section 3.10](/docs/03consensus/foliage "Section 3.10: Foliage")).
 + (+) Less susceptible to selfish mining attacks.
 + (+) Smaller orphan rates and forks, since blocks can be included in parallel.
 + (+) Continues to advance at nearly the same rate when space decreases, since only around 1/3 of blocks include transactions. PoW Nakamoto Consensus slows down linearly when hashrate drops.

--- a/docs/03consensus/foliage.md
+++ b/docs/03consensus/foliage.md
@@ -60,8 +60,10 @@ The average time between transaction blocks is 52 seconds. Several values are re
 * To create a transaction block, infusion_iterations first must be met, and then the next block some seconds afterwards will be a transaction block. The total average time for this to happen is around 52 seconds.
 * The formal equation is <img src="/img/block-time-calc.png" alt="(1/(e^(0.5)-1)+4)*9.375" width="200"/> or `(1/(e^(0.5)-1)+4)*9.375` which equals 51.95 seconds.
 
-The time between transaction blocks was deliberately chosen because it comes with several advantages:
+The time between transaction blocks was deliberately chosen for a specific game-theoretic reason: If transaction blocks occurred at the same rate but there were no empty blocks between them, re-orgs and bribery attacks would be easier to pull off.
+
+Additionally, the fact that there are empty blocks between transaction blocks provides several benefits:
+
 * If blocks were created at the same rate and all of them contained transactions, low-power machines such as the Raspberry Pi wouldn't be able to keep up with the chain and therefore wouldn't be supported.
-* If transaction blocks occurred at the same rate but there were no empty blocks between them, re-orgs and bribery attacks would be easier to pull off.
 * Empty blocks can also help dampen the effect of the chain slowing down, for example during a dust storm.
 * Finally, empty blocks help to smooth farmers' rewards.

--- a/docs/03consensus/overflow_blocks.md
+++ b/docs/03consensus/overflow_blocks.md
@@ -38,7 +38,7 @@ The block with deficit 15 is a challenge block.
 
 The normal case is where the deficit starts at 16, and goes down to zero within the sub-slot, and resets back to 16 as we finish the slot and start a new one. In the case that we don't manage to reduce it to 0 within the end of the sub-slot, the challenge chain and infused challenge chain (if present) continue, and the deficit does not reset to 16. Blocks (including overflow blocks now), keep subtracting from the deficit until we reach 0. When we finish a sub-slot with a zero deficit, the infused challenge chain is included into the challenge chain, and the deficit is reset to 16.
 
-This requirement was added to discourage long-range attacks, and is described in detail in [Section 3.14](/docs/03consensus/attacks_and_countermeasures#51-46-attack "Section 3.14: Attacks and Countermeasures"). The vast majority of sub-slots will have more than 16 blocks (recall that the average number is targeted to be 32), therefore the minimum-block requirement will not have much of an affect on normal operation. 
+This requirement was added to discourage long-range attacks, and is described in detail in [Section 3.14](/docs/03consensus/attacks_and_countermeasures#51-attack "Section 3.14: Attacks and Countermeasures"). The vast majority of sub-slots will have more than 16 blocks (recall that the average number is targeted to be 32), therefore the minimum-block requirement will not have much of an affect on normal operation. 
 
 <figure>
 <img src="/img/deficit.png" alt="drawing"/>
@@ -56,4 +56,4 @@ Both VDF speed and total amount of space are important for weight, and changes i
 
 A farmer with exclusive access to a slightly faster VDF, however, cannot easily get more rewards than a farmer with the normal speed VDF. If an attacker tries to orphan one of the blocks on the chain, having a faster VDF will not help, since the attacker’s chain will have fewer blocks (and thus a lower weight). Farmers must sign the block which they are building on top of, and they will only build on top of the highest weight chain. 
 
-The VDF speed comes into play when the attacker wishes to launch a 51% attack, however. In this case, an attacking farmer can use the VDF to create a completely alternate chain with no honest blocks, and overtake the honest chain. This requires slightly less than 51% of the space, since the faster VDF chain can obtain weight at a faster rate than the honest chain.
+The VDF speed comes into play when the attacker wishes to launch a 51% attack, however. In this case, an attacking farmer can use the VDF to create a completely alternate chain with no honest blocks, and overtake the honest chain. This requires 42.6% of the total netspace, since the faster VDF chain can obtain weight at a faster rate than the honest chain. This attack is described in detail in [Section 3.14](/docs/03consensus/attacks_and_countermeasures "Section 3.14: Attacks and Countermeasures").

--- a/docs/15resources/references.md
+++ b/docs/15resources/references.md
@@ -28,6 +28,7 @@ sidebar_position: 1
 * [POS Longest Chain Protocols](http://tselab.stanford.edu/downloads/PoS_LC_SBC2020.pdf), by Vivek Bagaria, Amir Dembo, Sreeram Kannan, Sewoong Oh, David Tse, Pramod Viswanath, Xuechao Wang, and Ofer Zeitouni
 * [Flyclient white paper](https://eprint.iacr.org/2019/226.pdf), by Benedikt Bunz, Lucianna Kiffer, Loi Luu, and Mahdi Zamani
 * [PoSAT white paper](https://arxiv.org/abs/2010.08154), by Soubhik Deb, Sreeram Kannan, and David Tse
+* [PoS security vs predictability](https://arxiv.org/pdf/1910.02218.pdf), by Vivek Bagaria, Amir Dembo, Sreeram Kannan, Sewoong Oh, David Tse, Pramod Viswanath, Xuechao Wang, and Ofer Zeitouni
 * [bech32m](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki) -- the address encoding scheme used by Chia
 * [x.509](https://en.wikipedia.org/wiki/X.509) -- the public key certificate used in Chia peer nodes
 * [DER](https://wiki.openssl.org/index.php/DER) -- a data structure used with x.509 certificates


### PR DESCRIPTION
The following percentages of the network space are required to run a successful long-range attack against Chia's network:

* No fast timelord: 42.6%
* Unlimited slightly faster timelords: 40.5%
* One timelord (3 VDFs) 2x faster than the second fastest: 33.4%
* Unlimited 2x faster timelords: 25%