### PR TITLE
fixed incorrect description of coin spend

### DIFF
--- a/docs/04coin-set-model/coin_set_vs_account.md
+++ b/docs/04coin-set-model/coin_set_vs_account.md
@@ -24,7 +24,7 @@ In Chia's coin set model, there are no accounts or balances. There are only coin
 
 A typical Chia transaction would look like the following:
 
-Alice wants to send 1 XCH to Bob. Alice has five coins in her wallet: four worth 0.2 XCH apiece, and one worth 0.7 XCH. Her wallet automatically selects two of the coins worth 0.2 XCH and the 0.7 XCH coin to be spent. All three coin spends happen simultaneously, along with two new coin creations: one worth 1 XCH which goes to Bob's wallet, and one worth 0.1 XCH which goes to Alice's wallet as "change." Alice now has two coins worth 0.2 XCH and one worth 0.1 XCH. Bob has one coin worth 1 XCH. The total value owned by Alice and Bob has not changed -- it was 1.5 XCH both before and after the transaction was processed.
+Alice wants to send 1 XCH to Bob. Alice has five coins in her wallet: four worth 0.2 XCH apiece, and one worth 0.7 XCH. Her wallet automatically selects four of the coins worth 0.2 XCH and the 0.7 XCH coin to be spent. All five coin spends happen simultaneously, along with two new coin creations: one worth 1 XCH which goes to Bob's wallet, and one worth 0.5 XCH which goes to Alice's wallet as "change." Now Alice has one coin worth 0.5 XCH and Bob has one coin worth 1 XCH. The total value owned by Alice and Bob has not changed -- it was 1.5 XCH both before and after the transaction was processed.
 
 Owner | Before            | After
 ----- | ----------------- | -------

--- a/docs/04coin-set-model/coin_set_vs_account.md
+++ b/docs/04coin-set-model/coin_set_vs_account.md
@@ -24,11 +24,11 @@ In Chia's coin set model, there are no accounts or balances. There are only coin
 
 A typical Chia transaction would look like the following:
 
-Alice wants to send 1 XCH to Bob. Alice has five coins in her wallet: four worth 0.2 XCH apiece, and one worth 0.7 XCH. Her wallet automatically selects four of the coins worth 0.2 XCH and the 0.7 XCH coin to be spent. All five coin spends happen simultaneously, along with two new coin creations: one worth 1 XCH which goes to Bob's wallet, and one worth 0.5 XCH which goes to Alice's wallet as "change." Now Alice has one coin worth 0.5 XCH and Bob has one coin worth 1 XCH. The total value owned by Alice and Bob has not changed -- it was 1.5 XCH both before and after the transaction was processed.
+Alice wants to send 1 XCH to Bob. Alice has five coins in her wallet: four worth 0.2 XCH apiece, and one worth 0.7 XCH. Her wallet automatically selects two of the coins worth 0.2 XCH and the 0.7 XCH coin to be spent. All three coin spends happen simultaneously, along with two new coin creations: one worth 1 XCH which goes to Bob's wallet, and one worth 0.1 XCH which goes to Alice's wallet as "change." Alice now has two coins worth 0.2 XCH and one worth 0.1 XCH. Bob has one coin worth 1 XCH. The total value owned by Alice and Bob has not changed -- it was 1.5 XCH both before and after the transaction was processed.
 
 Owner | Before            | After
 ----- | ----------------- | -------
-Alice | 1.5 XCH (5 coins) | 0.5 XCH (1 coin)
+Alice | 1.5 XCH (5 coins) | 0.5 XCH (3 coin)
 Bob   |   0 XCH           | 1.0 XCH (1 coin)
       |                   | 
 Total | 1.5 XCH           | 1.5 XCH

--- a/docs/04coin-set-model/intro.md
+++ b/docs/04coin-set-model/intro.md
@@ -55,4 +55,4 @@ Value may only be added to the coin set via the pre-farm (a one-time occurrence)
 Typically, in a block's combined spend bundle, value added will be equal to value spent, other than the block rewards. By definition, there are two possible exceptions:
 
 * Value added > value spent -- This is not allowed, so the transaction will be rejected. The rejection will usually happen at the mempool level, though a malicious actor could write their own mempool to accept the transaction, in which case the blockchain will reject it.
-* Value added < value spent -- This is allowed, so the transaction will succeed. In this case, the remaining value will be rewarded to the farmer of the block containing the transaction.
+* Value added =< value spent -- This is allowed, so the transaction will succeed. In this case, the remaining value will be rewarded to the farmer of the block containing the transaction.

--- a/docs/04coin-set-model/intro.md
+++ b/docs/04coin-set-model/intro.md
@@ -55,4 +55,4 @@ Value may only be added to the coin set via the pre-farm (a one-time occurrence)
 Typically, in a block's combined spend bundle, value added will be equal to value spent, other than the block rewards. By definition, there are two possible exceptions:
 
 * Value added > value spent -- This is not allowed, so the transaction will be rejected. The rejection will usually happen at the mempool level, though a malicious actor could write their own mempool to accept the transaction, in which case the blockchain will reject it.
-* Value added =< value spent -- This is allowed, so the transaction will succeed. If the value added is less than the value spent the remaining value will be rewarded to the farmer of the block containing the transaction awarded as a tip (you probably don't want to do that!).
+* Value added < value spent -- This is allowed, so the transaction will succeed. If the value added is less than the value spent the remaining value will be rewarded to the farmer of the block containing the transaction awarded as a tip (you probably don't want to do that!).

--- a/docs/04coin-set-model/intro.md
+++ b/docs/04coin-set-model/intro.md
@@ -55,4 +55,4 @@ Value may only be added to the coin set via the pre-farm (a one-time occurrence)
 Typically, in a block's combined spend bundle, value added will be equal to value spent, other than the block rewards. By definition, there are two possible exceptions:
 
 * Value added > value spent -- This is not allowed, so the transaction will be rejected. The rejection will usually happen at the mempool level, though a malicious actor could write their own mempool to accept the transaction, in which case the blockchain will reject it.
-* Value added =< value spent -- This is allowed, so the transaction will succeed. In this case, the remaining value will be rewarded to the farmer of the block containing the transaction.
+* Value added =< value spent -- This is allowed, so the transaction will succeed. If the value added is less than the value spent the remaining value will be rewarded to the farmer of the block containing the transaction awarded as a tip (you probably don't want to do that!).


### PR DESCRIPTION
Corrected the wording in the coin spend information to be consistent with the desired final state.