### PR TITLE
Two corrections based on 1.5.0 code

### DIFF
--- a/docs/12rpcs/nft_rpcs.mdx
+++ b/docs/12rpcs/nft_rpcs.mdx
@@ -60,7 +60,7 @@ Request Parameters:
 | series_number (deprecated) | False    | Beginning in Chia version 1.5, please use the `edition_number` parameter instead of this one
 | series_total  (deprecated) | False    | Beginning in Chia version 1.5, please use the `edition_count` RPC instead of this one
 | edition_number             | False    | If this NFT has multiple editions (multiple identical copies of an NFT), then this parameter indicates the edition number of this NFT. |
-| edition_count              | False    | If this NFT has multiple editions, then this parameter indicates the total number of editions of this NFT. This parameter should be used if and only if the `edition_number` parameter was also used |
+| edition_total              | False    | If this NFT has multiple editions, then this parameter indicates the total number of editions of this NFT. This parameter should be used if and only if the `edition_number` parameter was also used |
 | fee                        | False    | The one-time blockchain fee to be used upon minting the NFT                                                                                                                                       |
 
 <details>
@@ -382,7 +382,6 @@ Request Parameters:
 
 | Parameter | Required | Description                                          |
 | :-------- | :------- | :--------------------------------------------------- |
-| wallet_id | True     | The Wallet ID of the NFT from which to retrieve info |
 | coin_id   | True     | The coin ID of the NFT about which to retrieve info  |
 
 :::info


### PR DESCRIPTION
1) `nft_get_info` does not require a `wallet_id`
2) `nft_mint_nft` uses `edition_total` _not_ `edition_count`

Of note: the example response for `nft_get_nfts` uses `edition_count` and `edition_number`. The type declaration for `NFTInfo` in nft_info.py has `series_total` & `series_number`. So not sure if those are being remapped somewhere during serialization, is an oversight or a mistake in the example. It would make sense for it to be made consistent with the edition nomenclature.