### PR TITLE
specify the fee is in mojos in RPC docs

### DIFF
--- a/docs/rpc-reference/datalayer.mdx
+++ b/docs/rpc-reference/datalayer.mdx
@@ -36,7 +36,7 @@ We also have documented the [DataLayer CLI](/datalayer-cli) commands for interac
 
 By default, the DataLayer RPC API is exposed on port 8562. This is configured in `~/.chia/mainnet/config/config.yaml` under `data_layer:rpc_port`. This port must not be exposed publicly for security concerns.
 
-Commands that modify the blockchain include an optional fee (in mojos). This fee can be specified in two ways:
+Commands that modify the blockchain include an optional fee. This fee can be specified in two ways:
 
 1. The "fee" parameter can be configured explicitly in the command, as several of the examples in this document show
 2. If the fee option is not explicitly specified, then the `data_layer:fee` setting in `~/.chia/mainnet/config/config.yaml` will be used. By default, this is set to 1 billion mojos (0.001 XCH)

--- a/docs/rpc-reference/datalayer.mdx
+++ b/docs/rpc-reference/datalayer.mdx
@@ -36,7 +36,7 @@ We also have documented the [DataLayer CLI](/datalayer-cli) commands for interac
 
 By default, the DataLayer RPC API is exposed on port 8562. This is configured in `~/.chia/mainnet/config/config.yaml` under `data_layer:rpc_port`. This port must not be exposed publicly for security concerns.
 
-Commands that modify the blockchain include an optional fee. This fee can be specified in two ways:
+Commands that modify the blockchain include an optional fee (in mojos). This fee can be specified in two ways:
 
 1. The "fee" parameter can be configured explicitly in the command, as several of the examples in this document show
 2. If the fee option is not explicitly specified, then the `data_layer:fee` setting in `~/.chia/mainnet/config/config.yaml` will be used. By default, this is set to 1 billion mojos (0.001 XCH)

--- a/docs/rpc-reference/nfts.mdx
+++ b/docs/rpc-reference/nfts.mdx
@@ -62,7 +62,7 @@ Request Parameters:
 | series_total (deprecated)  | False    | Beginning in Chia version 1.5, please use the `edition_count` RPC instead of this one                                                                                                                |
 | edition_number             | False    | If this NFT has multiple editions (multiple identical copies of an NFT), then this parameter indicates the edition number of this NFT.                                                               |
 | edition_count              | False    | If this NFT has multiple editions, then this parameter indicates the total number of editions of this NFT. This parameter should be used if and only if the `edition_number` parameter was also used |
-| fee                        | False    | The one-time blockchain fee to be used upon minting the NFT                                                                                                                                          |
+| fee                        | False    | The one-time blockchain fee (in mojos) to be used upon minting the NFT                                                                                                                                          |
 
 <details>
 <summary>Example 1 - Mint an NFT without using a DID</summary>
@@ -315,7 +315,7 @@ Request Parameters:
 | wallet_id      | True     | The Wallet ID of the NFT to transfer                                                                                |
 | target_address | True     | The address to transfer the NFT to. For NFT0 this must be an XCH address. For NFT1 this could also be a DID address |
 | nft_coin_id    | True     | The coin ID of the NFT to transfer                                                                                  |
-| fee            | False    | The one-time blockchain fee to be used upon transferring the NFT                                                    |
+| fee            | False    | The one-time blockchain fee (in mojos) to be used upon transferring the NFT                                                    |
 
 <details>
 <summary>Example</summary>
@@ -462,7 +462,7 @@ Request Parameters:
 | nft_coin_id | True     | The coin ID of the NFT on which to add a URI                              |
 | key         | True     | Must be either `u` (data URI), `mu` (metadata URI), or `lu` (license URI) |
 | uri         | True     | The URI to add                                                            |
-| fee         | False    | The one-time blockchain fee to be used upon adding a URI                  |
+| fee         | False    | The one-time blockchain fee (in mojos) to be used upon adding a URI                  |
 
 :::info
 

--- a/docs/rpc-reference/offers.mdx
+++ b/docs/rpc-reference/offers.mdx
@@ -35,7 +35,7 @@ chia rpc wallet create_new_wallet '{\"wallet_type\": \"nft_wallet\"}'
 Creates a new offer.
 
 - **offer_dict**: A dictionary of the offer to create.
-- **fee:** An optional fee to include with the offer. Defaults to 0.
+- **fee:** An optional fee (in mojos) to include with the offer. Defaults to 0.
 - **validate_only:** Defaults to False. Set to True to verify the validity of a potential offer, rather than actually creating an offer.
 
 ```python
@@ -90,7 +90,7 @@ async def check_offer_validity(self, offer: Offer) -> bool:
 Takes (accepts) a specific offer, with a given fee.
 
 - **offer:** The offer to accept. Must be in the PENDING_ACCEPT state.
-- **fee:** An optional fee to include with the offer. Defaults to 0.
+- **fee:** An optional fee (in mojos) to include with the offer. Defaults to 0.
 
 ```python
 async def take_offer(self, offer: Offer, fee=uint64(0)) -> TradeRecord:
@@ -135,7 +135,7 @@ async def get_all_offers(self, file_contents: bool = False) -> List[TradeRecord]
 Cancel an offer with a specific identifier.
 
 - **trade_id:** The ID of the offer to examine. Can be retrieved from an offer file by calling `cdv inspect spendbundles <offer_file>`.
-- **fee:** An optional fee to include with the cancellation. Defaults to 0.
+- **fee:** An optional fee (in mojos) to include with the cancellation. Defaults to 0.
 - **secure:** Defaults to True, which means "cancel on blockchain," ie spend the coins being offered and create new coin's in the Maker's wallet. Set to False to cancel locally. See [cancellation](#cancellation 'Offer cancellation') for more info.
 
 ```python


### PR DESCRIPTION
Some of our RPC docs specify the fee is in mojos and some do not.  Since we use XCH in the GUI and CLI, it is important we are very clear about the units for fees in the RPC as it is not intuitive.  This PR adds clarifying text on any RPC reference to fees where the units are not specified.  