### PR TITLE
address flag in verify_signature RPC is not required

### DIFF
--- a/docs/rpc-reference/wallet.mdx
+++ b/docs/rpc-reference/wallet.mdx
@@ -1965,7 +1965,7 @@ Request Parameters:
 | pubkey    | TEXT | True     | The public key of the signature to verify        |
 | message   | TEXT | True     | The message to verify                            |
 | signature | TEXT | True     | The signature to verify                          |
-| address   | TEXT | True     | The address, which must be derived from `pubkey` |
+| address   | TEXT | False    | The address, which must be derived from `pubkey` |
 
 ---
 


### PR DESCRIPTION
Signed-off-by: danieljperry <d.perry@chia.net>