### PR TITLE
published location seems to be out of date

### DIFF
--- a/docs/guides/chialisp-primer/testnet-setup.md
+++ b/docs/guides/chialisp-primer/testnet-setup.md
@@ -18,7 +18,7 @@ If you are using Windows, we recommend PowerShell, and you may need to replace f
 5.  Run `chia init` to setup and configure Chia.
 6.  Run `chia keys generate` to prepare the wallet keys.
 7.  Run `chia configure -t true` to use the Testnet.
-8.  Download the [Testnet database](https://download.chia.net/testnet10/blockchain_v2_testnet10.sqlite.gz) and place it in the `~/.chia/testnet10/db` folder.
+8.  Download the [Testnet database](https://download.chia.net/testnet10/blockchain_v2_testnet10.sqlite.gz) and place it in the `~/.chia/mainnet/db` folder.
 9.  Finally, run `chia start node` to start the full node.
 
 ## Faucet


### PR DESCRIPTION
looks like the chia node now writes to ~/.chia/mainnet/db while configured for testnet