### PR TITLE
fix "Edit this page" links everywhere

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,7 +30,7 @@ const katex = require('rehype-katex');
             routeBasePath: '/',
             sidebarPath: require.resolve('./sidebars.js'),
             editUrl:
-              'https://github.com/Chia-Network/{{ REPOSITORY_NAME }}/blob/main/',
+              'https://github.com/Chia-Network/chia-docs/blob/main/',
             remarkPlugins: [math],
             rehypePlugins: [katex],
           },


### PR DESCRIPTION
Closes #287 

"Edit this page" links do not work because the `editUrl` in `docusaurus.config.js` is clearly templated but is never expanded for `REPOSITORY_NAME`

My quick look at docusaurus docs doesn't show any information on templating the config.
I also didn't find anywhere else `REPOSITORY_NAME` is used, so I ruled out it was injected at build time (like in github workflows or build scripts).

This change hardcodes the `editUrl` to what would be the expanded template. 

A simple test of rewriting the URL I was directed to with what's involved in this change confirms that it will place the user on the associated markdown file that they can then edit.