### PR TITLE
migrate last kb article to docs

### DIFF
--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -1497,3 +1497,7 @@ You should check out [CONTRIBUTING.md](https://github.com/Chia-Network/chia-bloc
 ### What microphone is Gene using?
 
 Gene uses an [Electro-Voice RE20](https://products.electrovoice.com/na/en/re20).
+
+### Isn't the current international monetary system good enough?
+
+No. Around the world, governments and banks cause problematic interactions that make banks difficult to trust, especially in volatile regions like Hong Kong, Venezuela Argentina or Lebanon. International payments, when they are available and work, are slow, expensive and insecure. International SWIFT wires often take 1-5 days. Correspondent banks often charge up to 3% and since the changes to banking since 9/11 and 2008, many countries have limited correspondent banks. International wire fraud losses are very large, and we have a better solution to mitigate these problems.


### PR DESCRIPTION
while updating the kb articles with links to their corresponding docs I noticed this last article that was not migrated with the original batch.

Once this is migrated, all kb articles will be within the docs site and a sunset period will start