### PR TITLE
add trailing slash to config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,6 +13,7 @@ const katex = require('rehype-katex');
     favicon: '/svg/chia-leaf-green.svg',
     organizationName: 'Chia-Network',
     projectName: 'chia-docs',
+    trailingSlash: true,
     i18n: {
       defaultLocale: 'en',
       locales: ['en', 'zh'],


### PR DESCRIPTION
adding the trailing slash eliminates a warning in build and aids with seo links