### PR TITLE
Update nft_get_nfts docs on ignore_size_limit

### DIFF
--- a/docs/rpc-reference/nfts.md
+++ b/docs/rpc-reference/nfts.md
@@ -518,7 +518,6 @@ Request Parameters:
 | wallet_id         | NUMBER  | True     | The Wallet ID from which to retrieve the NFTs                                  |
 | start_index       | NUMBER  | False    | The NFT index at which to start retrieving the NFTs [Default: `0`]             |
 | num               | NUMBER  | False    | The maximum number of NFTs to retrieve [Default: `0`]                          |
-| ignore_size_limit | BOOLEAN | False    | Set to `True` to ignore the size limit when retrieving NFTs [Default: `False`] |
 
 <details>
 <summary>Example</summary>

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/rpc-reference/nfts.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/rpc-reference/nfts.md
@@ -518,7 +518,6 @@ Request Parameters:
 | wallet_id           | NUMBER  | True     | The Wallet ID from which to retrieve the NFTs                                  |
 | start_index         | NUMBER  | False    | The NFT index at which to start retrieving the NFTs [Default: `0`]             |
 | num                 | NUMBER  | False    | The maximum number of NFTs to retrieve [Default: `0`]                          |
-| ignore_size_limit | BOOLEAN | False    | Set to `True` to ignore the size limit when retrieving NFTs [Default: `False`] |
 
 <details>
 <summary>Example</summary>


### PR DESCRIPTION
`ignore_size_limit` is not honored downstream and so it's effectively always `False`.