### PR TITLE
Fix padding on website margins

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -73,7 +73,7 @@ ol,
 li {
   list-style: none;
   margin: 0;
-  padding: 10px;
+  padding: 1px;
 }
 
 .carousel {
@@ -82,7 +82,7 @@ li {
 
 .carousel-inner {
   display: flex;
-  padding: 10px;
+  padding: 1px;
   overflow-x: scroll;
   counter-reset: item;
   scroll-behavior: smooth;


### PR DESCRIPTION
A previous commit (cfcebb8fd599170815d2907157fcd7dd8c857e0c) increased the spacing between menu items to 10 pixels on the main docs site, as well as the academy page. The old spacing had been 1 pixel for both. 

This PR restores the original spacing (1 pixel). Please review, as the changes to the style sheet could have changed something else inadvertently.

The following image shows the original spacing on the left, and the post-cfcebb spacing on the right:

![spacing](https://github.com/Chia-Network/chia-docs/assets/69756004/6013ef0f-5118-4d13-a1bb-e67444fd7a69)
