### PR TITLE
Fix URL for custody flowchart again

### DIFF
--- a/docs/guides/custody/custody-tool-user-guide.md
+++ b/docs/guides/custody/custody-tool-user-guide.md
@@ -21,7 +21,7 @@ This tool was _not_ originally developed with the broader ecosystem in mind. For
 Before continuing, you might want to familiarize yourself with the following documents:
 
 - [Basic description](/guides/custody-tool-description) of how the custody tool works
-- [Flow chart](https://docs.chia.net/assets/files/chia-custody-tool.png) to visualize how the custody tool works
+- [Flow chart](https://docs.chia.net/img/chia-custody-tool.png) to visualize how the custody tool works
 - [CLI reference](https://docs.chia.net/custody-tool) for all custody commands used in this tutorial
 
 :::info
@@ -60,35 +60,35 @@ cd internal-custody
 3. Create a new virtual environment and then activate it:
 
 <Tabs
-  defaultValue="windows"
-  groupId="os"
-  values={[
-    {label: 'Windows', value: 'windows'},
-    {label: 'Linux', value: 'linux'},
-    {label: 'macOS', value: 'macos'},
-  ]}>
-  <TabItem value="windows">
+defaultValue="windows"
+groupId="os"
+values={[
+{label: 'Windows', value: 'windows'},
+{label: 'Linux', value: 'linux'},
+{label: 'macOS', value: 'macos'},
+]}>
+<TabItem value="windows">
 
-   ```powershell
-   python -m venv venv
-   .\venv\Scripts\Activate.ps1
-   ```
+```powershell
+python -m venv venv
+.\venv\Scripts\Activate.ps1
+```
 
   </TabItem>
   <TabItem value="linux">
 
-   ```bash
-   python3 -m venv venv
-   . ./venv/bin/activate
-   ```
+```bash
+python3 -m venv venv
+. ./venv/bin/activate
+```
 
   </TabItem>
   <TabItem value="macos">
 
-   ```bash
-   python3 -m venv venv
-   . ./venv/bin/activate
-   ```
+```bash
+python3 -m venv venv
+. ./venv/bin/activate
+```
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
The previous URL was wrong somehow. I tried it locally and it seemed to work the first time, so not sure what's up with that.

Let's wait for deployment to make sure it's correct this time I suppose.