### PR TITLE
Fixed \ not showing up since it is escaped

### DIFF
--- a/docs/rpc-reference/full-node.md
+++ b/docs/rpc-reference/full-node.md
@@ -31,7 +31,7 @@ chia rpc full_node get_block '{"header_hash":"0xf42b4e77315d79ddfb3d64becb21e26e
 
 To run the same command on Windows, you need to escape the quotes with backslashes. In other words, add a \ before each double quote, such that:
 
-    "header_hash" becomes \"header_hash\"
+    "header_hash" becomes \\"header_hash\\"
 
 </details>
 


### PR DESCRIPTION
In the example for how to escape quotes in windows the slash does not show up since it is not escaped, Replaced \ with \\.