### PR TITLE
Resolve typos in bluebox timelord install from source instructions

### DIFF
--- a/docs/getting-started/timelords.md
+++ b/docs/getting-started/timelords.md
@@ -170,7 +170,7 @@ Once you build the Timelord with `sh install-timelord.sh` in the virtual environ
 - In the `full_node:` section and set `send_uncompact_interval:` to something greater than 0. We recommend `300` seconds there so that your Bluebox has some time to prove through a lot of the un-compacted Proofs of Time before the node drops more into its lap.
 
 ## Start the daemon, timelord-launcher, timelord, and node for a Bluebox timelord
-chia start full node_timelord
+chia start full_node timelord
 
 Note - The default settings may otherwise work but if the total effort is a little too much for whatever machine you are on you can also lower the `process_count:` from 3 to 2, or even 1, in the `timelord_launcher:` section. You know it is working if you see `VDF Client: Sent proof` in your logs at INFO level.
 

--- a/docs/getting-started/timelords.md
+++ b/docs/getting-started/timelords.md
@@ -162,7 +162,7 @@ chia init
 sh install-timelord.sh
 
 # Start timelord (skip this step and proceed below if installing a bluebox or ASIC timelord)
-chia start full_node timelord
+chia start node timelord
 
 # Bluebox timelord setup
 Once you build the Timelord with `sh install-timelord.sh` in the virtual environment, you will need to make two changes to `~/.chia/VERSION/config.yaml`.

--- a/docs/getting-started/timelords.md
+++ b/docs/getting-started/timelords.md
@@ -170,7 +170,7 @@ Once you build the Timelord with `sh install-timelord.sh` in the virtual environ
 - In the `full_node:` section and set `send_uncompact_interval:` to something greater than 0. We recommend `300` seconds there so that your Bluebox has some time to prove through a lot of the un-compacted Proofs of Time before the node drops more into its lap.
 
 ## Start the daemon, timelord-launcher, timelord, and node for a Bluebox timelord
-chia start full_node timelord
+chia start node timelord
 
 Note - The default settings may otherwise work but if the total effort is a little too much for whatever machine you are on you can also lower the `process_count:` from 3 to 2, or even 1, in the `timelord_launcher:` section. You know it is working if you see `VDF Client: Sent proof` in your logs at INFO level.
 


### PR DESCRIPTION
Modified the "chia start..." command to remove typos