### PR TITLE
Include log level rpcs

### DIFF
--- a/docs/rpc-reference/rpc.md
+++ b/docs/rpc-reference/rpc.md
@@ -203,9 +203,9 @@ Options:
 
 Request Services:
 
-| Type       | Required | Description                                                                                                                                                                              |
-| :--------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| STRING     | True     | The service to query; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet"            |
+| Type   | Required | Description                                                                                                                     |
+| :----- | :------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| STRING | True     | The service to query; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet" |
 
 Request Parameters: None
 
@@ -250,15 +250,15 @@ Options:
 
 Request Services:
 
-| Type       | Required | Description                                                                                                                                                                              |
-| :--------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| STRING     | True     | The service to query; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet"            |
+| Type   | Required | Description                                                                                                                     |
+| :----- | :------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| STRING | True     | The service to query; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet" |
 
 Request Parameters:
 
-| Flag          | Type       | Required | Description                                                                                                                                                                              |
-| :------------ | :--------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| level     | STRING     | True     | The log level to set for the designated service; valid levels are: "CRITICAL", "FATAL", "ERROR", "WARN", "WARNING", "INFO", "DEBUG", "NOTSET"               |
+| Flag  | Type   | Required | Description                                                                                                                                   |
+| :---- | :----- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
+| level | STRING | True     | The log level to set for the designated service; valid levels are: "CRITICAL", "FATAL", "ERROR", "WARN", "WARNING", "INFO", "DEBUG", "NOTSET" |
 
 <details>
 <summary>Example</summary>
@@ -306,9 +306,9 @@ Options:
 
 Request Services:
 
-| Type       | Required | Description                                                                                                                                                                              |
-| :--------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| STRING     | True     | The service to query; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet"            |
+| Type   | Required | Description                                                                                                                     |
+| :----- | :------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| STRING | True     | The service to query; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet" |
 
 Request Parameters: None
 

--- a/docs/rpc-reference/rpc.md
+++ b/docs/rpc-reference/rpc.md
@@ -235,6 +235,8 @@ Response:
 }
 ```
 
+</details>
+
 ### `set_log_level`
 
 Functionality: Set the services current log level
@@ -291,6 +293,8 @@ Response:
 }
 ```
 
+</details>
+
 ### `reset_log_level`
 
 Functionality: Reset the services current log level
@@ -338,3 +342,5 @@ Response:
   "success": true
 }
 ```
+
+</details>

--- a/docs/rpc-reference/rpc.md
+++ b/docs/rpc-reference/rpc.md
@@ -18,6 +18,8 @@ TLS certificates are used to secure the communication.
 - Harvester: 8560
 - Wallet: 9256
 - DataLayer: 8562
+- Crawler: 8561
+- Timelord: 8557
 
 ### HTTP/JSON
 
@@ -181,3 +183,158 @@ Each service is composed of a managed object, an API for control, and an RPC API
 - **Managed Objects**: This column details the core entities or components that each service oversees.
 - **Associated API**: This column specifies the API class associated with each service. This API class defines the interface for interacting with the corresponding managed objects.
 - **Associated RPC API**: This column lists the RPC API class associated with each service. This RPC API class allows for remote control of the managed objects through Remote Procedure Calls (RPC).
+
+## Log Levels
+
+Added in version 2.5.1, the below RPCs are for interacting with log levels for the various services while they are running running.
+
+### `get_log_level`
+
+Functionality: Get the services current log level
+
+Usage: chia rpc [SERVICE] get_log_level
+
+Options:
+
+| Short Command | Long Command | Type | Required | Description                                                         |
+| :------------ | :----------- | :--- | :------- | :------------------------------------------------------------------ |
+| -j            | --json-file  | TEXT | False    | Instead of REQUEST, provide a json file containing the request data |
+| -h            | --help       | None | False    | Show a help message and exit                                        |
+
+Request Services:
+
+| Type       | Required | Description                                                                                                                                                                              |
+| :--------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| STRING     | True     | The service to query; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet"            |
+
+Request Parameters: None
+
+<details>
+<summary>Example</summary>
+
+```json
+chia rpc wallet get_log_level
+```
+
+Response:
+
+```json
+{
+  "available_levels": [
+    "CRITICAL",
+    "FATAL",
+    "ERROR",
+    "WARN",
+    "WARNING",
+    "INFO",
+    "DEBUG",
+    "NOTSET"
+  ],
+  "level": "WARNING",
+  "success": true
+}
+```
+
+### `set_log_level`
+
+Functionality: Set the services current log level
+
+Usage: chia rpc [SERVICE] set_log_level
+
+Options:
+
+| Short Command | Long Command | Type | Required | Description                                                         |
+| :------------ | :----------- | :--- | :------- | :------------------------------------------------------------------ |
+| -j            | --json-file  | TEXT | False    | Instead of REQUEST, provide a json file containing the request data |
+| -h            | --help       | None | False    | Show a help message and exit                                        |
+
+Request Services:
+
+| Type       | Required | Description                                                                                                                                                                              |
+| :--------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| STRING     | True     | The service to query; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet"            |
+
+Request Parameters:
+
+| Flag          | Type       | Required | Description                                                                                                                                                                              |
+| :------------ | :--------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| level     | STRING     | True     | The log level to set for the designated service; valid levels are: "CRITICAL", "FATAL", "ERROR", "WARN", "WARNING", "INFO", "DEBUG", "NOTSET"               |
+
+<details>
+<summary>Example</summary>
+
+```json
+chia rpc wallet set_log_level '
+{
+    "level": "DEBUG"
+}'
+
+```
+
+Response:
+
+```json
+{
+  "available_levels": [
+    "CRITICAL",
+    "FATAL",
+    "ERROR",
+    "WARN",
+    "WARNING",
+    "INFO",
+    "DEBUG",
+    "NOTSET"
+  ],
+  "errors": [],
+  "level": "DEBUG",
+  "success": true
+}
+```
+
+### `reset_log_level`
+
+Functionality: Reset the services current log level
+
+Usage: chia rpc [SERVICE] reset_log_level
+
+Options:
+
+| Short Command | Long Command | Type | Required | Description                                                         |
+| :------------ | :----------- | :--- | :------- | :------------------------------------------------------------------ |
+| -j            | --json-file  | TEXT | False    | Instead of REQUEST, provide a json file containing the request data |
+| -h            | --help       | None | False    | Show a help message and exit                                        |
+
+Request Services:
+
+| Type       | Required | Description                                                                                                                                                                              |
+| :--------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| STRING     | True     | The service to query; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet"            |
+
+Request Parameters: None
+
+<details>
+<summary>Example</summary>
+
+```json
+chia rpc wallet reset_log_level
+```
+
+Response:
+
+```json
+{
+  "available_levels": [
+    "CRITICAL",
+    "FATAL",
+    "ERROR",
+    "WARN",
+    "WARNING",
+    "INFO",
+    "DEBUG",
+    "NOTSET"
+  ],
+  "errors": [],
+  "level": "WARNING",
+  "success": true
+}
+```

--- a/docs/rpc-reference/rpc.md
+++ b/docs/rpc-reference/rpc.md
@@ -203,9 +203,9 @@ Options:
 
 Request Services:
 
-| Type   | Required | Description                                                                                                                     |
-| :----- | :------- | :------------------------------------------------------------------------------------------------------------------------------ |
-| STRING | True     | The service to query; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet" |
+| Type   | Required | Description                                                                                                                                       |
+| :----- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------ |
+| STRING | True     | The service to query for its log level; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet" |
 
 Request Parameters: None
 
@@ -252,9 +252,9 @@ Options:
 
 Request Services:
 
-| Type   | Required | Description                                                                                                                     |
-| :----- | :------- | :------------------------------------------------------------------------------------------------------------------------------ |
-| STRING | True     | The service to query; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet" |
+| Type   | Required | Description                                                                                                                                   |
+| :----- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
+| STRING | True     | Set the log level for this service; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet" |
 
 Request Parameters:
 
@@ -310,9 +310,9 @@ Options:
 
 Request Services:
 
-| Type   | Required | Description                                                                                                                     |
-| :----- | :------- | :------------------------------------------------------------------------------------------------------------------------------ |
-| STRING | True     | The service to query; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet" |
+| Type   | Required | Description                                                                                                                                     |
+| :----- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------- |
+| STRING | True     | Reset the log level for this service; valid examples include: "crawler", "data_layer", "farmer", "full_node", "harvester", "timelord", "wallet" |
 
 Request Parameters: None
 


### PR DESCRIPTION
2.5.1 introduced new rpcs to control the services log levels. This pr adds those endpoints to the rpc overview doc page.