### PR TITLE
Add android chia signer

### DIFF
--- a/docs/chia-signer/faq.md
+++ b/docs/chia-signer/faq.md
@@ -50,6 +50,12 @@ The linking process involves scanning a QR code displayed by your Chia Cloud Wal
 
 When you initiate a transaction from your linked Chia Cloud Wallet, the Chia Signer app on your signing device will receive a request. You will review the transaction details presented on the Signer app's screen and, if correct, tap "Sign transaction." Your device may require a biometric (Face ID, Touch ID, fingerprint) or passcode confirmation to authorize the signing.
 
+### Does Chia Network have access to my Signer keys, or can CNI recover my vault if I lose both keys?
+
+**No.** Chia Network, Inc. (CNI) does **not** have access to your **spend keys** or **recovery keys**, whether they are held in the Chia Signer app, as passkeys, or as a BLS recovery phrase you manage yourself. Signing material is generated and kept under your control; CNI does not hold copies in a form that would let us sign on your behalf.
+
+If you permanently lose access to **both** your spend key and your recovery key (including backups), **CNI cannot recover your keys or restore vault access for you**.
+
 ### Is an Android version of the Chia Signer app available?
 
 Yes, the android version is currently in beta: [Google Play](https://play.google.com/store/apps/details?id=net.chia.android.signer).

--- a/docs/chia-signer/faq.md
+++ b/docs/chia-signer/faq.md
@@ -10,28 +10,34 @@ import TabItem from '@theme/TabItem';
 
 ### What is the Chia Signer app?
 
-The Chia Signer app is a dedicated mobile application currently available for iOS devices designed to provide an enhanced layer of security for your Chia Wallet transactions. It allows you to securely store your private keys in your phone's Secure Enclave and approve transactions initiated from your Chia Wallet.
+The Chia Signer app is a dedicated mobile application for iOS and Android that provides an enhanced layer of security for your Chia Wallet transactions. On iOS, keys are stored in the Secure Enclave. Android is currently in **beta**; on first launch the app checks for hardware-backed key storage via Android’s Keystore (including StrongBox or TEE-backed storage when the device supports it). If suitable hardware is not available, you can still use software keys; the app warns you on each software key creation that the key is not hardware-protected.
 
 ### What are the key benefits of using the Chia Signer app?
 
-- **Secure Enclave Protection:** Your private keys are generated and stored within your device's Secure Enclave, a hardware-isolated security component. This means your keys never leave your device and are highly protected against software vulnerabilities.
+- **Hardware-protected keys:** Your private keys are generated and stored in hardware-isolated security components on the device. They are not exposed to normal app memory and are highly protected against many software-level attacks.
 - **Secure, Device-Based Approval:** The Signer app allows you to securely approve transactions initiated from your Chia Cloud Wallet on a separate, dedicated device.
 - **Enhanced Security:** By separating your signing key from your main Chia Cloud Wallet interface (requiring two devices), it adds a significant layer of security against online threats and unauthorized access.
 
 ### What are the device requirements for the Chia Signer app?
 
-To use the Chia Signer app, your iOS device must:
+**iOS**
 
-- Run **iOS 15 or later**.
-- Have a **Secure Enclave** (most iPhone models starting with iPhone 6s and iPad models starting with iPad mini 4 or newer typically have this).
+- See the [App Store listing](https://apps.apple.com/app/chia-signer/id6504493785) for compatible devices and the minimum iOS version. In general, you need iOS 15 or later and a Secure Enclave.
+
+**Android** (beta)
+
+- The Android app is in **beta**. Use the [Google Play listing](https://play.google.com/store/apps/details?id=net.chia.android.signer) for compatible devices, OS version, and install eligibility. Hardware-backed keys require device support for Android’s hardware-backed Keystore (e.g. StrongBox or TEE); see Google’s [Keystore documentation](https://developer.android.com/privacy-and-security/keystore). Devices without that backing use software keys with in-app notices at creation time as these keys are inherently less secure than hardware keys.
 
 ### Can I use the Chia Cloud Wallet and the Chia Signer app on the same device?
 
-Currently, no. For security purposes, you need two separate devices: one for accessing your Chia Cloud Wallet (e.g., a computer or another phone) and a separate iOS device with the Chia Signer app installed. This functionality (using both on the same device) is planned for a future release.
+Currently, no. For security purposes, you need two separate devices: one for accessing your Chia Cloud Wallet (e.g., a computer or another phone) and a separate smartphone with the Chia Signer app (iOS, or Android in beta). Using both on the same device is planned for a future release.
 
 ### How do I create a new key within the Chia Signer app?
 
-After opening the app for the first time, you can tap the `+` button, name your key, and select "Generate Key." This will securely generate a new private key within your device's Secure Enclave.
+Tap the `+` button, name your key, and select **Generate Key**.
+
+- **iOS:** The app creates a hardware-backed key in the Secure Enclave.
+- **Android** (beta): On first start, the app checks for hardware-backed Keystore support (StrongBox or TEE per your device). If supported, you get hardware-backed keys. If not, you can create software keys only, and the app alerts you each time that the new key is a software key.
 
 ### How do I link my Chia Signer key to a Chia Cloud Wallet vault?
 
@@ -42,12 +48,24 @@ The linking process involves scanning a QR code displayed by your Chia Cloud Wal
 
 ### How do I sign a transaction using the Chia Signer app?
 
-When you initiate a transaction from your linked Chia Cloud Wallet, the Chia Signer app on your iOS device will receive a request. You will review the transaction details presented on the Signer app's screen and, if correct, tap "Sign transaction." Your device may require a biometric (Face ID/Touch ID) or passcode confirmation to authorize the signing.
+When you initiate a transaction from your linked Chia Cloud Wallet, the Chia Signer app on your signing device will receive a request. You will review the transaction details presented on the Signer app's screen and, if correct, tap "Sign transaction." Your device may require a biometric (Face ID, Touch ID, fingerprint) or passcode confirmation to authorize the signing.
 
 ### Is an Android version of the Chia Signer app available?
 
-Currently, the Chia Signer app is only available for iOS devices. An Android version is planned for a future release.
+Yes, the android version is currently in beta: [Google Play](https://play.google.com/store/apps/details?id=net.chia.android.signer).
 
 ### Can the Chia Signer app be used as the Chia Cloud Wallet recovery key?
 
-Currently, the Chia Signer app can only be used as the custody key for your vault but the ability to use it for the recovery key is planned for a future release.
+Yes. Your vault’s recovery key remains a BLS key with an associated 24-word mnemonic seed phrase; the Chia Signer app can store and use that BLS recovery key for you. Spend keys cannot be BLS—they stay passkeys or Chia Signer hardware/software keys.
+
+We strongly recommend keeping the recovery key on a different device than the spend key. If both the spend key and BLS recovery material live only on the same phone and you lose access to it, you may be unable to spend or complete recovery. Chia Network cannot reset your keys or restore vault access for you.
+
+If recovery and spend might share one device, or you use Signer-held recovery in any other setup, back up your recovery credentials with care:
+
+- On Apple devices, use iCloud Keychain with Advanced Data Protection enabled.
+
+- On Android, use encrypted credential storage and backups tied to a strongly secured Google account: a screen lock, 2-step verification, and passkeys or hardware security keys where available. A password manager with strong 2FA is also appropriate.
+
+- On any platform, use a reputable password manager secured with strong 2FA—prefer passkeys or hardware security keys for the manager and your cloud accounts, not SMS-only verification.
+
+Treat any copy of recovery material like any other 24 word mnemonic seed phrase: anyone who obtains it may be able to attempt recovery.

--- a/docs/chia-signer/getting-started.md
+++ b/docs/chia-signer/getting-started.md
@@ -48,7 +48,7 @@ After installing and opening the app for the first time:
 
 The Android app is in **beta**. When you first start the app, it checks whether your device supports **hardware-backed key storage** through Android’s [Keystore](https://developer.android.com/privacy-and-security/keystore) system. Depending on the device, that may use:
 
-- **StrongBox** — dedicated tamper-resistant hardware (a discrete secure module) used for Android’s hardware-backed Keystore on devices that ship StrongBox, or  
+- **StrongBox** — dedicated tamper-resistant hardware (a discrete secure module) used for Android’s hardware-backed Keystore on devices that ship StrongBox, or
 - **TEE-backed Keystore** — keys handled inside a Trusted Execution Environment when StrongBox is not available but the device still offers hardware-isolated key storage.
 
 If the device **does not** provide the required hardware backing, the app will only offer **software keys**.
@@ -56,7 +56,6 @@ If the device **does not** provide the required hardware backing, the app will o
 ### Generate Key on Android
 
 3.  **Generate Key:** Tap **Generate Key** and follow the prompts.
-
     - **Hardware available:** You can create **hardware-backed keys** (private key material remains in secure hardware).
     - **No suitable hardware:** You can create **software keys** only. **Each time** you create a key, the app **alerts you** that you are creating a **software key** (not hardware-protected).
 

--- a/docs/chia-signer/getting-started.md
+++ b/docs/chia-signer/getting-started.md
@@ -12,17 +12,20 @@ This guide will show you how to get started with the Chia Signer app, from setti
 
 **Prerequisites:**
 
-- An iOS device (iPhone or iPad) running iOS 15 or later and has the Secure Enclave.
+- A compatible phone or tablet for the Chia Signer app:
+  - **iOS:** iPhone or iPad running **iOS 15 or later** with a **Secure Enclave**. Requirements are kept up to date on the [App Store](https://apps.apple.com/app/chia-signer/id6504493785) listing.
+  - **Android** (beta): Phone or tablet that meets the requirements shown on the [Google Play listing](https://play.google.com/store/apps/details?id=net.chia.android.signer). For the strongest protection, use a device that supports **hardware-backed Keystore** (including **StrongBox** where available); if the device does not, the app can still run using **software keys** with clear in-app warnings when you create each key.
 
 **Key Concepts:**
 
-- **Secure Enclave Protection:** Your private keys are generated and stored in your device's Secure Enclave, a dedicated hardware security module, ensuring they never leave your device.
+- **Hardware-protected keys (recommended):** On **iOS**, keys live in the **Secure Enclave**. On **Android** (beta), keys can be stored using Android’s **hardware-backed Keystore**, which may use **StrongBox** (dedicated tamper-resistant hardware) or a **Trusted Execution Environment (TEE)** when the device supports it, see Google’s [Android Keystore overview](https://developer.android.com/privacy-and-security/keystore). If your Android device does not expose suitable hardware backing, the app falls back to **software keys** and **warns you at each key creation** that the key is software-based.
 - **Secure, Device-Based Approval:** The Signer app allows you to securely approve transactions initiated from your Chia Cloud Wallet on a separate, dedicated device.
-- **Two-Device Requirement:** Currently, the Chia Cloud Wallet and Chia Signer app must be on separate devices (e.g., Chia Cloud Wallet on your computer/phone, Signer on your iPhone).
+- **Two-Device Requirement:** Currently, the Chia Cloud Wallet and Chia Signer app must be on separate devices (for example, Chia Cloud Wallet on your computer or phone, and Signer on another smartphone).
 
 ## 1. Get the Chia Signer App
 
-- **Download:** The Chia Signer app is available on the [iOS App Store](https://apps.apple.com/app/chia-signer/id6504493785). (Note: An Android version is planned for the future).
+- **iOS:** [App Store](https://apps.apple.com/app/chia-signer/id6504493785).
+- **Android** (beta): [Google Play](https://play.google.com/store/apps/details?id=net.chia.android.signer).
 
 ## 2. Create a New Key in the Chia Signer App
 
@@ -30,9 +33,37 @@ After installing and opening the app for the first time:
 
 1.  **Add Key:** Tap the `+` button, usually located in the upper-right corner of the app's main screen.
 2.  **Name Your Key:** Enter a descriptive name for your key (e.g., "My Vault Key" or "Main Signer Key").
-3.  **Generate Key:** Select the option to "Generate Key" (currently, the only option is to create a hardware key directly in your device's Secure Enclave). Tap `Generate Key`. (NOTE: Software key options planned for the future).
-    - Your device will securely generate and store a new private key within its Secure Enclave.
-4.  **View Key:** Your newly created key will now appear on the app's main screen.
+
+<Tabs groupId="signer-create-key">
+<TabItem value="ios" label="iOS">
+
+### Generate Key on iOS
+
+3.  **Generate Key:** Tap **Generate Key**. The app creates a **hardware-backed key** in your device’s **Secure Enclave**. Private key material stays in that hardware and is not exposed to normal app memory.
+
+</TabItem>
+<TabItem value="android" label="Android (beta)">
+
+### Hardware check on first start
+
+The Android app is in **beta**. When you first start the app, it checks whether your device supports **hardware-backed key storage** through Android’s [Keystore](https://developer.android.com/privacy-and-security/keystore) system. Depending on the device, that may use:
+
+- **StrongBox** — dedicated tamper-resistant hardware (a discrete secure module) used for Android’s hardware-backed Keystore on devices that ship StrongBox, or  
+- **TEE-backed Keystore** — keys handled inside a Trusted Execution Environment when StrongBox is not available but the device still offers hardware-isolated key storage.
+
+If the device **does not** provide the required hardware backing, the app will only offer **software keys**.
+
+### Generate Key on Android
+
+3.  **Generate Key:** Tap **Generate Key** and follow the prompts.
+
+    - **Hardware available:** You can create **hardware-backed keys** (private key material remains in secure hardware).
+    - **No suitable hardware:** You can create **software keys** only. **Each time** you create a key, the app **alerts you** that you are creating a **software key** (not hardware-protected).
+
+</TabItem>
+</Tabs>
+
+5.  **View Key:** Your newly created key will now appear on the app's main screen.
 
 ## 3. Link Your Chia Signer Key to a Chia Cloud Wallet Vault
 
@@ -42,7 +73,7 @@ This step connects your secure key in the Signer app to a specific vault created
 
 2.  **Link Key from Chia Signer App:**
     There are two primary methods to link a key, depending on whether you've already created the key in the Signer app or are linking for the first time:
-    - **Method A: Linking an Existing Key (Key selected in Step 2)**
+    - **Method A: Linking an Existing Key (after you have created and named a key above)**
       1.  Open the Chia Signer app and ensure your existing key is visible on the main screen.
       2.  Tap on the specific key you wish to link.
       3.  Locate and tap the "Link Key" button (this will activate your device's camera).
@@ -66,7 +97,7 @@ Once linked, your Signer app becomes the gatekeeper for all transactions from th
 
 1.  **Initiate Transaction (from Chia Cloud Wallet):** When you want to send funds or perform other actions from your Chia Cloud Wallet, you will set up the transaction details in the Chia Cloud Wallet interface and click "Send" or confirm the action.
 2.  **Receive Signing Request (on Chia Signer App):** The Chia Signer app will automatically receive a transaction signing request. You will see a notification or the app will open, displaying the transaction details.
-3.  **Review Details:** **Carefully review all the transaction details** shown on your Chia Signer app screen (e.g., recipient address, amount, fee). This is your last chance to verify the transaction before it is sent.
+3.  **Review Details:** Carefully review all the transaction details shown on your Chia Signer app screen (e.g., recipient address, amount, fee). This is your last chance to verify the transaction before it is sent.
 4.  **Sign Transaction:** If the details are correct, scroll down and tap the `Sign transaction` button within the Chia Signer app.
-    - Your device may require a biometric (Face ID/Touch ID) or passcode confirmation to authorize the signing.
+    - Your device may require a biometric (Face ID, Touch ID, fingerprint) or passcode confirmation to authorize the signing.
 5.  **Confirmation:** Once signed, the transaction is sent to the Chia network via your Chia Cloud Wallet, and you should see a confirmation message on both the Signer app and the Chia Cloud Wallet.

--- a/docs/cloud-wallet/faq.md
+++ b/docs/cloud-wallet/faq.md
@@ -188,6 +188,12 @@ In general, as more vaults, Cloud Wallet accounts, hardware keys, and software k
 
 ## Security and privacy
 
+### Does Chia Network have access to my vault keys, or can CNI recover my vault if I lose them?
+
+**No.** Chia Network, Inc. (CNI) does **not** have access to your vault’s **spend keys** or **recovery keys**. Those credentials stay with you—on your devices, with your passkey provider, or wherever you stored your recovery material—and are not held by CNI in a form that would let us sign transactions or recovery on your behalf.
+
+If you permanently lose access to **both** your spend key and your recovery key (including any usable backup of your recovery phrase), **CNI cannot recover your keys or restore access to your vault**. Self-custody means there is no master key or back door; only someone who holds the required keys can spend or complete recovery.
+
 ### Will CNI be able to freeze and/or confiscate my assets?
 
 No. CNI won't custody any of your assets, so it won't have the ability to freeze or confiscate them. If the Cloud Wallet website were forcibly shut down, you would still have the ability to spend your assets because you would still be in control of the keys associated with your vault. However, the infrastructure to accomplish this would need to be rebuilt.

--- a/docs/cloud-wallet/faq.md
+++ b/docs/cloud-wallet/faq.md
@@ -89,7 +89,7 @@ Feel free to ask questions in the #support channel of [our Discord](https://disc
 
 ### Where can I report a bug?
 
-If you find any bugs, feel free to fill out the in-app reporting form accessible by clicking you profile image in the top right then "Report an Issue". 
+If you find any bugs, feel free to fill out the in-app reporting form accessible by clicking you profile image in the top right then "Report an Issue".
 
 If you discover any security issues, you can file a report on our [bug bounty site](https://hackerone.com/chia_network). Thanks for your help!
 

--- a/docs/cloud-wallet/faq.md
+++ b/docs/cloud-wallet/faq.md
@@ -15,6 +15,7 @@ The Cloud Wallet is a platform for interacting with the Chia blockchain. Assets 
 ### Is the Chia Cloud Wallet available for mainnet?
 
 Yes, the Chia Cloud Wallet was released on 10/29/2025 and can be accessed [here](https://vault.chia.net).
+The testnet version of the Chia Cloud Wallet can be accessed [here](https://vault.chiatest.net/).
 
 ### How can I obtain some TXCH for testnet11?
 
@@ -24,6 +25,7 @@ Visit either our [official faucet site](https://testnet11-faucet.chia.net) or a 
 
 For mainnet visit the [Mainnet Cloud Wallet website](https://vault.chia.net) and sign up for a free account.
 For testnet visit the [Testnet Cloud Wallet website](https://vault.chiatest.net) and sign up for a free account.
+You can refer to our [Getting Started Guide](/cloud-wallet/getting-started) for help setting up your account.
 
 ### How is the Cloud Wallet different from other wallets?
 
@@ -87,7 +89,7 @@ Feel free to ask questions in the #support channel of [our Discord](https://disc
 
 ### Where can I report a bug?
 
-If you find any bugs, feel free to fill out a [bug report](https://docs.google.com/forms/d/e/1FAIpQLSeIAZAxSwTwZPGUVLs7_XKseoPgOmtBa0qhtWNQwBeoo9adRA/viewform). However, please keep in mind that this is early release software. We are aware of several existing bugs.
+If you find any bugs, feel free to fill out the in-app reporting form accessible by clicking you profile image in the top right then "Report an Issue". 
 
 If you discover any security issues, you can file a report on our [bug bounty site](https://hackerone.com/chia_network). Thanks for your help!
 
@@ -133,14 +135,16 @@ Yes! The Chia blockchain is a public ledger, so anyone can build software to mon
 
 ### What is the Chia Signer app?
 
-The Chia Signer app turns your smartphone into a hardware wallet. The app uses your phone's Secure Enclave to create a vault spend key. This key cannot be removed from the device, so a thief would need to gain physical access to your phone in order to steal it. You can download it from the [iOS App Store](https://apps.apple.com/app/chia-signer/id6504493785).
+The Chia Signer app turns your smartphone into a hardware wallet. The app uses **hardware-protected storage** on your phone (Secure Enclave on iOS; hardware-backed keystore / StrongBox on supported Android devices, the Android app is in **beta**) to create a vault spend key. This key cannot be removed from the device, so a thief would need to gain physical access to your phone in order to steal it.
+
+Download **iOS** from the [App Store](https://apps.apple.com/app/chia-signer/id6504493785). **Android** is in **beta** on [Google Play](https://play.google.com/store/apps/details?id=net.chia.android.signer).
 
 :::info
 
 Currently, in order to use the Chia Signer app, you will need two separate devices:
 
 1. A computer or phone to access your vault
-2. An iOS device on which the Chia Signer app is installed
+2. A smartphone (iOS, or Android in beta) with the Chia Signer app installed
 
 You cannot use both the Cloud Wallet and the Chia Signer app on the same device yet. However, we do intend to enable this functionality in a future release.
 
@@ -148,25 +152,23 @@ You cannot use both the Cloud Wallet and the Chia Signer app on the same device 
 
 ### Is the Chia Signer app available for both Android and iOS?
 
-It is currently only available for iOS. We will build an Android version in the future.
+Yes.
+
+**iOS:** [App Store](https://apps.apple.com/app/chia-signer/id6504493785).
+
+**Android** (beta): [Google Play](https://play.google.com/store/apps/details?id=net.chia.android.signer).
 
 ### On which iOS devices is the Chia Signer app supported?
 
-The app has two requirements for iOS devices:
+See the [App Store listing](https://apps.apple.com/app/chia-signer/id6504493785) for the current minimum OS version and device compatibility. In general, the app targets **iOS 15 or later** on devices with a **Secure Enclave**.
 
-1. The device must run iOS 15 or later
-2. The device must have a Secure Enclave
+### On which Android devices is the Chia Signer app supported?
 
-The following devices meet both of these requirements:
-
-- iPhone models beginning with the iPhone 6
-- iPad models beginning with the iPad mini 4
-
-Be sure to double check that your device is running at least iOS 15 prior to installing the Chia Signer app.
+The Android app is in **beta**. Supported devices and OS requirements are shown on the [Google Play listing](https://play.google.com/store/apps/details?id=net.chia.android.signer). The Play Store is the most up-to-date source for compatibility.
 
 ### Is it safe to install the Chia Signer app on a second-hand device?
 
-Yes -- just be sure to do a factory reset of the device first. See [Apple's support site](https://support.apple.com/guide/iphone/iph7a2a9399b/ios) for instructions.
+Yes -- just be sure to **factory reset** the device first so any prior owner's data and keys are wiped. For **iOS**, see [Apple's support site](https://support.apple.com/guide/iphone/iph7a2a9399b/ios). For **Android**, see [Google's guide to resetting your device](https://support.google.com/android/answer/6088915).
 
 ### Does the Chia Signer app use blind signing?
 

--- a/docs/cloud-wallet/getting-started.md
+++ b/docs/cloud-wallet/getting-started.md
@@ -43,7 +43,7 @@ Congratulations, you're all set to create your first vault!
 Currently, in order to use the Chia Signer app, you will need two separate devices:
 
 1. A computer or phone to access your vault
-2. An iOS device on which the Chia Signer app is installed
+2. A smartphone (iOS, or Android in beta) with the Chia Signer app installed
 
 You cannot use both the Cloud Wallet and the Chia Signer app on the same device yet. However, we do intend to enable this functionality in a future release.
 
@@ -57,9 +57,7 @@ You cannot use both the Cloud Wallet and the Chia Signer app on the same device 
 
 2. Give your vault a name, for example `My Signer Vault`.
 
-3. You will need to scan the QR code using your Chia Signer app. If you don't have the app yet, you can download it from the [iOS App Store](https://apps.apple.com/app/chia-signer/id6504493785).
-
-   Note: The Chia Signer app currently is only built for iOS devices. We will build an Android version of the app in the future.
+3. You will need to scan the QR code using your Chia Signer app. If you don't have the app yet: **iOS** — [App Store](https://apps.apple.com/app/chia-signer/id6504493785); **Android** (beta) — [Google Play](https://play.google.com/store/apps/details?id=net.chia.android.signer).
 
    <div style={{ textAlign: 'left' }}>
      <img src="/img/cloud-wallet/03_choose_vault_type.png" alt="Create vault with signer app" width="100%"/>
@@ -71,7 +69,7 @@ You cannot use both the Cloud Wallet and the Chia Signer app on the same device 
   <img src="/img/cloud-wallet/04_new_key.png" alt="Create a new key" width="40%"/>
 </div>
 
-5. Give your new key a name, for example `My Key`. Currently, the only option is to create a hardware key directly in your device's Secure Enclave. Tap `Generate Key`:
+5. Give your new key a name, for example `My Key`. Currently, the only option is to create a hardware-backed key in your device's secure hardware (Secure Enclave on iOS; hardware-backed keystore on Android, which is in beta). Tap `Generate Key`:
 
 <div style={{ textAlign: 'left' }}>
   <img src="/img/cloud-wallet/05_generate_key.png" alt="Generate a hardware key" width="40%"/>

--- a/docs/cloud-wallet/tooltips.md
+++ b/docs/cloud-wallet/tooltips.md
@@ -16,7 +16,7 @@ This is the process of rekeying a vault. It will allow you to change any combina
 
 If you still have access to your spend key, you can recover your vault without having to wait for the clawback period to expire. There are three primary use cases for Instant Recovery (also known as Instant Rekey):
 
-1. **New Device** -- If you use the Chia Signer app, then your vault's spend key is stored in your smartphone's Secure Element. It can never be copied or moved to another device, so when you obtain a new phone, you will need to recover your vault. As long as you still have your original phone, you can instantly rekey your vault to use your new device.
+1. **New Device** -- If you use the Chia Signer app, then your vault's spend key is stored in hardware-protected storage on your smartphone. It can never be copied or moved to another device, so when you obtain a new phone, you will need to recover your vault. As long as you still have your original phone, you can instantly rekey your vault to use your new device.
 
 2. **Emergency Recovery** -- If an adversary obtains a copy of your recovery key (for example, your 24-word phrase), then the adversary can attempt to recover your vault in order to drain its funds. However, they will need to wait for the recovery clawback period to expire before doing so. You will receive an email as a warning that the recovery attempt is in progress. As long as you still have your spend key (e.g. your smart phone or your passkey), you can cancel the recovery attempt, and instantly rekey your vault's recovery phrase to a new one. The adversary will no longer be able to attempt to steal your funds.
 
@@ -54,7 +54,7 @@ This is the amount of time you must wait before a recovery operation can be comp
 
 ## Signer App
 
-A smartphone app initially available for iPhones made after 2013. The app stores a spend key in its Secure Enclave. This key cannot be copied or removed from the phone, so the only way to steal it is to gain physical access to the device. For this reason, we strongly recommend that you secure the Signer app using your phone’s biometrics.
+A smartphone app for **iOS** and **Android** (Android is in **beta**). The app stores a spend key in hardware-protected storage on the device (Secure Enclave on iOS; hardware-backed keystore / StrongBox on supported Android devices). This key cannot be copied or removed from the phone, so the only way to steal it is to gain physical access to the device. For this reason, we strongly recommend that you secure the Signer app using your phone’s biometrics. **iOS:** [App Store](https://apps.apple.com/app/chia-signer/id6504493785). **Android** (beta): [Google Play](https://play.google.com/store/apps/details?id=net.chia.android.signer).
 
 ## Clawback
 
@@ -75,7 +75,7 @@ Please read this section before deciding on which types of keys to use in your v
 
 ### App (Hardware key)
 
-Create a key in your iPhone's Secure Enclave (coming soon for Android phones). This key can never be removed from your device. See our [Getting Started Guide](/chia-signer/getting-started/) for more info.
+Create a hardware-backed key in your device's secure hardware (Secure Enclave on iOS; hardware-backed keystore on Android, currently in beta). This key can never be removed from your device. See our [Getting Started Guide](/chia-signer/getting-started/) for more info.
 
 #### Bottom Line
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates; low risk aside from potential user confusion if platform/security claims are inaccurate.
> 
> **Overview**
> Updates Signer and Cloud Wallet docs to reflect **Android Chia Signer availability (beta)** alongside iOS, including new Google Play links and updated two-device guidance.
> 
> Clarifies key storage behavior across platforms (Secure Enclave vs Android Keystore/StrongBox/TEE, with software-key fallback warnings) and expands FAQs with guidance on recovery-key usage/backups plus explicit statements that **CNI cannot access or recover users’ spend/recovery keys**. Also refreshes Cloud Wallet FAQ with the testnet URL, a getting-started link, and switches bug reporting instructions to the in-app flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b933fb8aa3d8cb43221c20d9c8ab9ce009e521c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->