### PR TITLE
Update info about Android TEE and StrongBox

### DIFF
--- a/docs/chia-signer/faq.md
+++ b/docs/chia-signer/faq.md
@@ -34,10 +34,29 @@ Currently, no. For security purposes, you need two separate devices: one for acc
 
 ### How do I create a new key within the Chia Signer app?
 
-Tap the `+` button, name your key, and select **Generate Key**.
+Tap the ellipsis (the `...` button in the upper-right corner), then tap the `+ Add Key` button, name your key, optionally change the emoji, and select **Generate Key**. We recommend that you leave the `Secure your key` slider enabled.
+
+You also have the option to create either a `Hardware key` (a spend key) or a `Software key` (a recovery key). If you choose `Hardware key`, then the key's location will depend on your phone's hardware and OS:
 
 - **iOS:** The app creates a hardware-backed key in the Secure Enclave.
-- **Android** (beta): On first start, the app checks for hardware-backed Keystore support (StrongBox or TEE per your device). If supported, you get hardware-backed keys. If not, you can create software keys only, and the app alerts you each time that the new key is a software key.
+- **Android** (beta): On first start, the app checks for hardware-backed Keystore support. Depending on your phone's manufacturer and model, one of three options will be selected automatically:
+  - StrongBox
+    - most secure option
+    - uses a dedicated Hardware Security Module (HSM)
+    - resistant to hardware tampering
+    - only available on select Android devices ([list of currently supported devices](https://www.android-device-security.org/database/?sortBy=COUNT%20Lab%20Strongbox%20True;COUNT%20Lab%20Strongbox%20False&order=-1&show=Strongbox&Strongbox=True&realMeasurementsOnly=true))
+  - Trusted Execution Environment (TEE)
+    - less secure than StrongBox
+    - separates secure and non-secure execution environments
+    - available on most Android devices
+  - Neither
+    - least secure option
+    - Signer app will fall back to using a software key
+    - Signer app will alert you each time that the new key is a software key
+
+### Is a TEE secure enough to be used with the Android Signer app?
+
+This depends on your risk assessment. A key stored in a TEE is at a higher risk of compromise than one stored in a StrongBox. [This article](https://www.comviva.com/blog/safeguarding-cryptographic-keys-implementing-tee-and-strongbox-in-android-applications/) describes the differences between the environments. If you feel that a TEE is not secure enough (for example, if you plan to store large amounts of funds in a Cloud Wallet vault), then you can acquire a device with a StrongBox for the highest level of security available on an Android device.
 
 ### How do I link my Chia Signer key to a Chia Cloud Wallet vault?
 

--- a/docs/chia-signer/faq.md
+++ b/docs/chia-signer/faq.md
@@ -54,9 +54,17 @@ You also have the option to create either a `Hardware key` (a spend key) or a `S
     - Signer app will fall back to using a software key
     - Signer app will alert you each time that the new key is a software key
 
+:::info
+
+The Android Chia Signer app currently shows the same messaging for phones with a TEE and for those that only support software keys. We will update this messaging in a future release. If your phone does have a TEE, the hardware keys will be created in the TEE despite this messaging.
+
+:::
+
 ### Is a TEE secure enough to be used with the Android Signer app?
 
-This depends on your risk assessment. A key stored in a TEE is at a higher risk of compromise than one stored in a StrongBox. [This article](https://www.comviva.com/blog/safeguarding-cryptographic-keys-implementing-tee-and-strongbox-in-android-applications/) describes the differences between the environments. If you feel that a TEE is not secure enough (for example, if you plan to store large amounts of funds in a Cloud Wallet vault), then you can acquire a device with a StrongBox for the highest level of security available on an Android device.
+Our security best practice for the Android Signer app is to use a phone with a StrongBox. However, depending on your personal risk assessment, a phone with a TEE may also suffice.
+
+A key stored in a TEE is at a higher risk of compromise than one stored in a StrongBox. [This article](https://www.comviva.com/blog/safeguarding-cryptographic-keys-implementing-tee-and-strongbox-in-android-applications/) describes the differences between the environments. If you feel that a TEE is not secure enough (for example, if you plan to store large amounts of funds in a Cloud Wallet vault), then you can acquire a device with a StrongBox for the highest level of security available on an Android device.
 
 ### How do I link my Chia Signer key to a Chia Cloud Wallet vault?
 

--- a/docs/chia-signer/getting-started.md
+++ b/docs/chia-signer/getting-started.md
@@ -31,7 +31,7 @@ This guide will show you how to get started with the Chia Signer app, from setti
 
 After installing and opening the app for the first time:
 
-1.  **Add Key:** Tap the `+` button, usually located in the upper-right corner of the app's main screen.
+1.  **Add Key:** Tap the ellipsis (the `...` button in the upper-right corner), then tap the `+ Add Key` button.
 2.  **Name Your Key:** Enter a descriptive name for your key (e.g., "My Vault Key" or "Main Signer Key").
 
 <Tabs groupId="signer-create-key">

--- a/docs/cloud-wallet/faq.md
+++ b/docs/cloud-wallet/faq.md
@@ -117,6 +117,10 @@ You can use your spend key to send your funds to a new vault.
 
 A recovery key can only be used for recovering a vault. If this key is stolen, the thief will not immediately be able to steal your funds. However, they will likely attempt to recover your vault. In this case, the watchtower will send you an email notifying you that your vault is now in recovery mode. The recovery can only be completed after a preset timer has expired. Until this time, you can cancel the recovery and move your funds to a new vault.
 
+### If I initiate a recovery, and wait for the clawback timer to expire, and then someone steals my recovery key, can the thief swap my keys for theirs without having to re-initiate a recovery?
+
+No. When you initiate the recovery, you lock in the new keys. The only way to change them is to cancel the recovery and re-initiate it. After the timer expires, the only two options are 1) complete the recovery with exactly the keys you entered, or 2) cancel the recovery and start over. If the thief only has your recovery key, then there is no option to change the keys without waiting for the recovery clawback timer to expire.
+
 ## Watchtowers
 
 ### What is a watchtower?


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates clarifying Android key storage options and a recovery edge case; no runtime or security-sensitive code changes.
> 
> **Overview**
> Updates Signer documentation to reflect the current UI flow for adding keys (via the `...` menu) and expands Android guidance to distinguish **StrongBox vs TEE vs software fallback**, including an explicit note about current in-app messaging limitations and a new FAQ on whether TEE is sufficient.
> 
> Extends the Cloud Wallet FAQ with a new recovery scenario clarifying that once a recovery is initiated, the replacement keys are locked in and can’t be swapped without cancelling and re-initiating recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec086bd8fdd8ff790fe634556da59a2648ab0cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->