### PR TITLE
Consolidate Dependabot PRs

### DIFF
--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -56,7 +56,7 @@ jobs:
           passphrase: ${{ secrets.CHIA_AUTOMATION_PRIVATE_GPG_PASSPHRASE }}
 
       - name: crowdin action
-        uses: crowdin/github-action@v2.14.0
+        uses: crowdin/github-action@v2.16.0
         with:
           upload_sources: false
           upload_translations: false

--- a/.github/workflows/crowdin-push.yml
+++ b/.github/workflows/crowdin-push.yml
@@ -34,7 +34,7 @@ jobs:
             secret/data/crowdin project-id-docs | CROWDIN_PROJECT_ID;
 
       - name: crowdin action
-        uses: crowdin/github-action@v2.14.0
+        uses: crowdin/github-action@v2.16.0
         with:
           upload_sources: true
           upload_translations: false

--- a/.github/workflows/deploy-review.yml
+++ b/.github/workflows/deploy-review.yml
@@ -60,30 +60,30 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
       - name: Download build from artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: build
           path: ./build
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/${{ github.repository }}
           tags: |
             type=sha,format=long
       - name: Build Docker Container
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "chia-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@docsearch/react": "^4.6.0",
+        "@docsearch/react": "^4.6.2",
         "@docusaurus/core": "^3.9.1",
         "@docusaurus/plugin-google-gtag": "^3.9.1",
         "@docusaurus/preset-classic": "^3.9.1",
@@ -19,7 +19,7 @@
         "prism-react-renderer": "^2.4.1",
         "react": "^19.2.3",
         "react-dom": "^19.2.4",
-        "react-icons": "^5.5.0",
+        "react-icons": "^5.6.0",
         "react-simple-code-editor": "^0.14.1",
         "rehype-katex": "^7.0.1",
         "remark-math": "^6.0.0"
@@ -3198,9 +3198,9 @@
       }
     },
     "node_modules/@docsearch/core": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.0.tgz",
-      "integrity": "sha512-IqG3oSd529jVRQ4dWZQKwZwQLVd//bWJTz2HiL0LkiHrI4U/vLrBasKB7lwQB/69nBAcCgs3TmudxTZSLH/ZQg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.2.tgz",
+      "integrity": "sha512-/S0e6Dj7Zcm8m9Rru49YEX49dhU11be68c+S/BCyN8zQsTTgkKzXlhRbVL5mV6lOLC2+ZRRryaTdcm070Ug2oA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3220,20 +3220,20 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.0.tgz",
-      "integrity": "sha512-YlcAimkXclvqta47g47efzCM5CFxDwv2ClkDfEs/fC/Ak0OxPH2b3czwa4o8O1TRBf+ujFF2RiUwszz2fPVNJQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.2.tgz",
+      "integrity": "sha512-fH/cn8BjEEdM2nJdjNMHIvOVYupG6AIDtFVDgIZrNzdCSj4KXr9kd+hsehqsNGYjpUjObeKYKvgy/IwCb1jZYQ==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.0.tgz",
-      "integrity": "sha512-j8H5B4ArGxBPBWvw3X0J0Rm/Pjv2JDa2rV5OE0DLTp5oiBCptIJ/YlNOhZxuzbO2nwge+o3Z52nJRi3hryK9cA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.2.tgz",
+      "integrity": "sha512-/BbtGFtqVOGwZx0dw/UfhN/0/DmMQYnulY4iv0tPRhC2JCXv0ka/+izwt3Jzo1ZxXS/2eMvv9zHsBJOK1I9f/w==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/core": "4.6.0",
-        "@docsearch/css": "4.6.0"
+        "@docsearch/core": "4.6.2",
+        "@docsearch/css": "4.6.2"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -15635,9 +15635,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
-      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docsearch/react": "^4.6.0",
+    "@docsearch/react": "^4.6.2",
     "@docusaurus/core": "^3.9.1",
     "@docusaurus/plugin-google-gtag": "^3.9.1",
     "@docusaurus/preset-classic": "^3.9.1",
@@ -30,7 +30,7 @@
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.4",
-    "react-icons": "^5.5.0",
+    "react-icons": "^5.6.0",
     "react-simple-code-editor": "^0.14.1",
     "rehype-katex": "^7.0.1",
     "remark-math": "^6.0.0"


### PR DESCRIPTION
- Bump crowdin/github-action v2.14.0 to v2.16.0 (crowdin-pull, crowdin-push)
- Bump actions/download-artifact v7 to v8; Docker actions in deploy-review (setup-qemu, setup-buildx, login, metadata, build-push)
- Bump @docsearch/react to ^4.6.2 and react-icons to ^5.6.0; refresh lockfile

Supersedes dependency PRs: #963, #962, #942, #941, #940, #939, #937, #935, #929.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only updates across CI workflows and the docs frontend; main potential impact is CI/deploy workflow behavior changes from major action version bumps.
> 
> **Overview**
> Updates CI tooling versions: bumps `crowdin/github-action` in the Crowdin pull/push workflows and upgrades the review-app deployment workflow to newer `actions/download-artifact` and Docker GitHub Actions major versions.
> 
> Refreshes docs frontend dependencies by bumping `@docsearch/react` (and its `@docsearch/*` transitive deps) plus `react-icons`, and updates `package-lock.json` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cec08ce69fa23e98b20d3f841363b5a94782d320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->