### PR TITLE
add recovery page

### DIFF
--- a/docs/chia-signer/getting-started.md
+++ b/docs/chia-signer/getting-started.md
@@ -66,7 +66,7 @@ If the device **does not** provide the required hardware backing, the app will o
 
 ## 3. Link Your Chia Signer Key to a Chia Cloud Wallet Vault
 
-This step connects your secure key in the Signer app to a specific vault created in the Chia Cloud Wallet.
+This step connects your secure key in the Signer app to a specific vault created in the Chia Cloud Wallet. Your spend key cannot be copied off the device; when you get a new phone, you rekey the vault from the Cloud Wallet while you still have the old device. See the [Recovery](/cloud-wallet/recovery) guide.
 
 1.  **Initiate Linking (from Chia Cloud Wallet):** On your separate device (where you access your Chia Cloud Wallet), you will begin the process of creating or linking a vault as described [here](/cloud-wallet/getting-started). The Chia Cloud Wallet will display a **QR Code**.
 

--- a/docs/chia-signer/getting-started.md
+++ b/docs/chia-signer/getting-started.md
@@ -62,11 +62,11 @@ If the device **does not** provide the required hardware backing, the app will o
 </TabItem>
 </Tabs>
 
-5.  **View Key:** Your newly created key will now appear on the app's main screen.
+4.  **View Key:** Your newly created key will now appear on the app's main screen.
 
 ## 3. Link Your Chia Signer Key to a Chia Cloud Wallet Vault
 
-This step connects your secure key in the Signer app to a specific vault created in the Chia Cloud Wallet. Your spend key cannot be copied off the device; when you get a new phone, you rekey the vault from the Cloud Wallet while you still have the old device. See the [Recovery](/cloud-wallet/recovery) guide.
+This step connects your secure key in the Signer app to a specific vault created in the Chia Cloud Wallet. Your spend key cannot be copied off the device; so when you get a new phone and still have your old phone you will want to use your spend key to instantly rekey your vault, if you do not have your old phone you will need to use your recovery phrase and timelocked recovery to rekey your vault. See the [Recovery](/cloud-wallet/recovery) guide.
 
 1.  **Initiate Linking (from Chia Cloud Wallet):** On your separate device (where you access your Chia Cloud Wallet), you will begin the process of creating or linking a vault as described [here](/cloud-wallet/getting-started). The Chia Cloud Wallet will display a **QR Code**.
 

--- a/docs/cloud-wallet/faq.md
+++ b/docs/cloud-wallet/faq.md
@@ -113,11 +113,11 @@ However, the current setup is not secure against wrench attacks, where the thief
 
 ### What happens if I lose my recovery key?
 
-If you still have your spend key, use [Instant Recovery](/cloud-wallet/recovery) to set a new recovery key in a single on-chain step. You confirm the change and sign with your current spend key, with no recovery clawback wait. See the [Recovery](/cloud-wallet/recovery) guide for context. If you have lost both your spend key and any usable backup of your recovery phrase, you cannot regain access to the vault.
+If you still have your spend key, use [Instant Recovery](/cloud-wallet/recovery/#instant-recovery) to set a new recovery key in a single on-chain step. You confirm the change and sign with your current spend key, with no recovery clawback wait. See the [Recovery](/cloud-wallet/recovery) guide for context. If you have lost both your spend key and any usable backup of your recovery phrase, you cannot regain access to the vault.
 
 ### What happens if my recovery key is stolen? Will all of my funds be stolen?
 
-A recovery key can only be used for recovering a vault. If this key is stolen, the thief will not immediately be able to steal your funds. However, they will likely attempt to recover your vault. In this case, the watchtower will send you an email notifying you that your vault is now in recovery mode. The recovery can only be completed after a preset timer has expired. Until then, you can cancel the recovery with your spend key during the clawback window. After you cancel, use [Instant Recovery](/cloud-wallet/recovery) to rotate your compromised recovery key to a new one so the stolen material no longer works. (You can still move funds to a new vault if you prefer, but Instant Recovery is the direct way to fix the keys on your existing vault.)
+A recovery key can only be used for recovering a vault. If this key is stolen, the thief will not immediately be able to steal your funds. However, they will likely attempt to recover your vault. In this case, the watchtower will send you an email notifying you that your vault is now in recovery mode. The recovery can only be completed after a preset timer has expired. Until then, you can cancel the recovery with your spend key during the clawback window. After you cancel, use [Instant Recovery](/cloud-wallet/recovery/#instant-recovery) to rotate your compromised recovery key to a new one so the stolen material no longer works. (You can still move funds to a new vault if you prefer, but Instant Recovery is the direct way to fix the keys on your existing vault.)
 
 ### If I initiate a recovery, and wait for the clawback timer to expire, and then someone steals my recovery key, can the thief swap my keys for theirs without having to re-initiate a recovery?
 
@@ -137,7 +137,7 @@ Yes. During Instant Recovery you can update any combination of spend key, recove
 
 ### What happens if someone initiates a malicious recovery on my vault?
 
-You receive an email alert. If you still have your spend key, cancel the recovery during the clawback window, then use [Instant Recovery](/cloud-wallet/recovery) to set a new recovery key so the attacker’s copy of the old recovery material cannot be used again. See [Recovery](/cloud-wallet/recovery).
+You receive an email alert. If you still have your spend key and the malicious actor is using timelocked recovery, log into the Chia Cloud Wallet to cancel recovery during the clawback window using your spend key, then use [Instant Recovery](/cloud-wallet/recovery/#instant-recovery) to set a new recovery key so the attacker’s copy of the old recovery material cannot be used again. Note - if the attacker has gained access to your spend key they can use instant recovery to rekey both the spend and recovery key in which there is nothing you nor we at Chia Network, Inc. can do to recover the vault or stop the attacker. See [Recovery](/cloud-wallet/recovery).
 
 ## Watchtowers
 

--- a/docs/cloud-wallet/faq.md
+++ b/docs/cloud-wallet/faq.md
@@ -99,6 +99,8 @@ Currently the only tier you can choose is the `Free` tier, which only allows you
 
 ## Recovery
 
+For a conceptual overview of Instant Recovery and timelocked recovery, see the [Recovery](/cloud-wallet/recovery) guide.
+
 ### What happens if I lose my spend key?
 
 You can use your recovery key to swap out the lost key for a new one.
@@ -111,15 +113,31 @@ However, the current setup is not secure against wrench attacks, where the thief
 
 ### What happens if I lose my recovery key?
 
-You can use your spend key to send your funds to a new vault.
+If you still have your spend key, use [Instant Recovery](/cloud-wallet/recovery) to set a new recovery key in a single on-chain step. You confirm the change and sign with your current spend key, with no recovery clawback wait. See the [Recovery](/cloud-wallet/recovery) guide for context. If you have lost both your spend key and any usable backup of your recovery phrase, you cannot regain access to the vault.
 
 ### What happens if my recovery key is stolen? Will all of my funds be stolen?
 
-A recovery key can only be used for recovering a vault. If this key is stolen, the thief will not immediately be able to steal your funds. However, they will likely attempt to recover your vault. In this case, the watchtower will send you an email notifying you that your vault is now in recovery mode. The recovery can only be completed after a preset timer has expired. Until this time, you can cancel the recovery and move your funds to a new vault.
+A recovery key can only be used for recovering a vault. If this key is stolen, the thief will not immediately be able to steal your funds. However, they will likely attempt to recover your vault. In this case, the watchtower will send you an email notifying you that your vault is now in recovery mode. The recovery can only be completed after a preset timer has expired. Until then, you can cancel the recovery with your spend key during the clawback window. After you cancel, use [Instant Recovery](/cloud-wallet/recovery) to rotate your compromised recovery key to a new one so the stolen material no longer works. (You can still move funds to a new vault if you prefer, but Instant Recovery is the direct way to fix the keys on your existing vault.)
 
 ### If I initiate a recovery, and wait for the clawback timer to expire, and then someone steals my recovery key, can the thief swap my keys for theirs without having to re-initiate a recovery?
 
 No. When you initiate the recovery, you lock in the new keys. The only way to change them is to cancel the recovery and re-initiate it. After the timer expires, the only two options are 1) complete the recovery with exactly the keys you entered, or 2) cancel the recovery and start over. If the thief only has your recovery key, then there is no option to change the keys without waiting for the recovery clawback timer to expire.
+
+### What is Instant Recovery?
+
+Instant Recovery lets you rekey your vault immediately using your current spend key: you can change your spend key, recovery key, recovery timelock, or any combination of those, in one confirmed transaction, without waiting for the recovery clawback timer. Common reasons include getting a new phone (Chia Signer keys cannot be copied off the old device), replacing a lost recovery phrase while you still can sign, or rotating a compromised recovery key after you cancel a malicious timelocked recovery. Details: [Recovery](/cloud-wallet/recovery).
+
+### When should I use Instant Recovery vs Timelocked Recovery?
+
+If you still have your spend key, use Instant Recovery. If you cannot use your spend key anymore but you do have your recovery phrase (recovery key), use Timelocked Recovery and wait for the clawback period before completing recovery. See [Recovery](/cloud-wallet/recovery).
+
+### Can I use Instant Recovery to change just my recovery key (or just my timelock) without changing my spend key?
+
+Yes. During Instant Recovery you can update any combination of spend key, recovery key, and recovery timelock. You are not required to rotate everything at once.
+
+### What happens if someone initiates a malicious recovery on my vault?
+
+You receive an email alert. If you still have your spend key, cancel the recovery during the clawback window, then use [Instant Recovery](/cloud-wallet/recovery) to set a new recovery key so the attacker’s copy of the old recovery material cannot be used again. See [Recovery](/cloud-wallet/recovery).
 
 ## Watchtowers
 

--- a/docs/cloud-wallet/getting-started.md
+++ b/docs/cloud-wallet/getting-started.md
@@ -107,7 +107,7 @@ You cannot use both the Cloud Wallet and the Chia Signer app on the same device 
 
 11. Next, copy the 24 words to a safe location. You will need to recall these words in order to recover your vault, so don't lose them.
 
-12. You can also set a custom time for your vault's recovery clawback. This is the amount of time you will need to wait in order to recover your vault. If your 24-word recovery phrase is stolen, then you will have this long to cancel the recovery.
+12. You can also set a custom time for your vault's recovery clawback. This is the amount of time you will need to wait in order to recover your vault. If your 24-word recovery phrase is stolen, then you will have this long to cancel the recovery. For how Instant Recovery and timelocked recovery work together, see the [Recovery](/cloud-wallet/recovery) guide.
 
 13. Click the `Create` button to create your vault. A "vault faucet" will mint a new vault for you. Your vault's receive address will appear after this process is complete (typically a minute or two).
 

--- a/docs/cloud-wallet/recovery.md
+++ b/docs/cloud-wallet/recovery.md
@@ -3,7 +3,7 @@ title: Recovery
 slug: /cloud-wallet/recovery
 ---
 
-In the Cloud Wallet, recovery means rekeying your vault: you change one or more of the vault’s spend key, recovery key, and/or recovery timelock. Recovery does not move your coins to a different vault by itself; it updates which keys and rules control the vault you already have.
+In the Cloud Wallet, recovery means rekeying your vault: you change one or more of the vault’s spend key, recovery key, and/or recovery timelock. Recovery does not move your coins to a different vault by itself; it updates which keys and recovery timelock/clawback rules control the vault you already have.
 
 There are two ways to recover a vault: Instant Recovery and Timelocked Recovery. They address different situations depending on whether you still have your spend key.
 
@@ -19,13 +19,13 @@ Primary use cases:
 
 1. New device. If you use the Chia Signer app, your spend key lives in hardware-backed storage on your phone and cannot be copied to another device. When you get a new phone, you migrate by rekeying. As long as you still have the old device, you can use Instant Recovery to point the vault at keys on the new device.
 
-2. Emergency or compromised recovery key. If someone else gets your recovery material (for example your 24-word phrase) and starts timelocked recovery, they must wait for the recovery clawback period. You will receive an email alert for the attempted recovery. You cancel that recovery with your spend key during the clawback window, then use Instant Recovery to set a new recovery key so the compromised recovery key is no longer valid.
+2. Emergency or compromised recovery key. If someone else gets your recovery material (for example your 24-word phrase) and starts a timelocked recovery, they must wait for the recovery clawback timer to expire. You will receive an email alert for the attempted recovery. You cancel that recovery with your spend key during the clawback window, then use Instant Recovery to set a new recovery key so the compromised recovery key is no longer valid.
 
 3. Lost recovery key. If you still have your spend key but never backed up your recovery phrase (or lost it), you are not stuck forever: use Instant Recovery to install a new recovery key without waiting.
 
 ### Requirements
 
-- You must still possess the vault’s current spend key. Instant Recovery is not available if the spend key is lost, stolen in a way you cannot use, or otherwise inaccessible. In those cases you use Timelocked Recovery with your recovery key (if you have it).
+You must still possess the vault’s current spend key. Instant Recovery is not available if the spend key is lost, stolen in a way you cannot use, or otherwise inaccessible. In those cases you use Timelocked Recovery with your recovery key (if you have it).
 
 ### How it works (high level)
 
@@ -37,7 +37,7 @@ Timelocked Recovery is for when you no longer have access to your spend key, for
 
 ### What you need
 
-- Your recovery key (for example your 24-word recovery phrase for a BLS recovery key).
+Your recovery key (for example your 24-word recovery phrase for a BLS recovery key).
 
 ### What to expect
 
@@ -59,4 +59,4 @@ If you lose both your spend key and your recovery key (with no usable backup), n
 
 ## Recovery clawback
 
-When a vault is created, you set a recovery clawback duration (a waiting period). If someone starts timelocked recovery, that timer must elapse before the recovery can finish. The delay gives the legitimate owner, who may still have the spend key, time to see an alert (for example by email) and cancel a malicious attempt. Instant Recovery does not replace this mechanism for the timelocked path; it is the fast path when the spend key is still yours.
+When a vault is created, you set a recovery clawback duration (a waiting period). If someone starts a timelocked recovery, that timer must elapse before the recovery can finish. The delay gives the legitimate owner, who may still have the spend key, time to see an alert (for example by email) and cancel a malicious attempt. Instant Recovery does not replace this mechanism for the timelocked path; it is the fast path when the spend key is still yours.

--- a/docs/cloud-wallet/recovery.md
+++ b/docs/cloud-wallet/recovery.md
@@ -23,7 +23,6 @@ Primary use cases:
 
 3. Lost recovery key. If you still have your spend key but never backed up your recovery phrase (or lost it), you are not stuck forever: use Instant Recovery to install a new recovery key without waiting.
 
-
 ### Requirements
 
 - You must still possess the vault’s current spend key. Instant Recovery is not available if the spend key is lost, stolen in a way you cannot use, or otherwise inaccessible. In those cases you use Timelocked Recovery with your recovery key (if you have it).
@@ -52,13 +51,12 @@ If you lose both your spend key and your recovery key (with no usable backup), n
 
 ## Which should I use?
 
-| Situation | Path |
-| --- | --- |
-| You still have your spend key | Instant Recovery: fast rekey, no clawback wait for the rekey itself. |
-| You lost your spend key (or cannot use it) | Timelocked Recovery: use your recovery phrase and wait for the clawback period before completing recovery. |
-| Your recovery key is compromised | Cancel any pending timelocked recovery with your spend key during the clawback window, then Instant Recovery to rotate to a new recovery key. |
+| Situation                                  | Path                                                                                                                                          |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| You still have your spend key              | Instant Recovery: fast rekey, no clawback wait for the rekey itself.                                                                          |
+| You lost your spend key (or cannot use it) | Timelocked Recovery: use your recovery phrase and wait for the clawback period before completing recovery.                                    |
+| Your recovery key is compromised           | Cancel any pending timelocked recovery with your spend key during the clawback window, then Instant Recovery to rotate to a new recovery key. |
 
 ## Recovery clawback
 
 When a vault is created, you set a recovery clawback duration (a waiting period). If someone starts timelocked recovery, that timer must elapse before the recovery can finish. The delay gives the legitimate owner, who may still have the spend key, time to see an alert (for example by email) and cancel a malicious attempt. Instant Recovery does not replace this mechanism for the timelocked path; it is the fast path when the spend key is still yours.
-

--- a/docs/cloud-wallet/recovery.md
+++ b/docs/cloud-wallet/recovery.md
@@ -1,0 +1,64 @@
+---
+title: Recovery
+slug: /cloud-wallet/recovery
+---
+
+In the Cloud Wallet, recovery means rekeying your vault: you change one or more of the vault’s spend key, recovery key, and/or recovery timelock. Recovery does not move your coins to a different vault by itself; it updates which keys and rules control the vault you already have.
+
+There are two ways to recover a vault: Instant Recovery and Timelocked Recovery. They address different situations depending on whether you still have your spend key.
+
+## Instant Recovery
+
+Instant Recovery (also called Instant Rekey) lets you rotate your vault’s spend key, recovery key, and/or recovery timelock immediately, in a single transaction, with no waiting period. You prove you still control the vault by signing with your current spend key. The app asks you to confirm explicitly; nothing runs automatically.
+
+### When to use it
+
+Use Instant Recovery when you still have your spend key and you need to change keys or the timelock without going through timelocked recovery.
+
+Primary use cases:
+
+1. New device. If you use the Chia Signer app, your spend key lives in hardware-backed storage on your phone and cannot be copied to another device. When you get a new phone, you migrate by rekeying. As long as you still have the old device, you can use Instant Recovery to point the vault at keys on the new device.
+
+2. Emergency or compromised recovery key. If someone else gets your recovery material (for example your 24-word phrase) and starts timelocked recovery, they must wait for the recovery clawback period. You will receive an email alert for the attempted recovery. You cancel that recovery with your spend key during the clawback window, then use Instant Recovery to set a new recovery key so the compromised recovery key is no longer valid.
+
+3. Lost recovery key. If you still have your spend key but never backed up your recovery phrase (or lost it), you are not stuck forever: use Instant Recovery to install a new recovery key without waiting.
+
+
+### Requirements
+
+- You must still possess the vault’s current spend key. Instant Recovery is not available if the spend key is lost, stolen in a way you cannot use, or otherwise inaccessible. In those cases you use Timelocked Recovery with your recovery key (if you have it).
+
+### How it works (high level)
+
+You choose the new spend key, recovery key, and/or timelock values the vault should use next. You confirm the action in the app. You sign the rekey transaction with your existing spend key. After the transaction confirms on-chain, the vault is updated immediately. There is no clawback wait for this path.
+
+## Timelocked Recovery
+
+Timelocked Recovery is for when you no longer have access to your spend key, for example if your phone is lost or damaged and you cannot sign with the Signer key anymore.
+
+### What you need
+
+- Your recovery key (for example your 24-word recovery phrase for a BLS recovery key).
+
+### What to expect
+
+You initiate recovery with the recovery key and propose the new keys/timelock. The vault enforces a recovery clawback period before the recovery can be completed. During that window, anyone who still has the old spend key can cancel the recovery. After the timer expires, you complete recovery with the keys you locked in when you started (you cannot silently swap to different keys mid-flight without going through the rules described in the [FAQ](/cloud-wallet/faq#recovery)).
+
+:::warning
+
+If you lose both your spend key and your recovery key (with no usable backup), no recovery path can restore the vault. Chia Network does not hold copies of your keys.
+
+:::
+
+## Which should I use?
+
+| Situation | Path |
+| --- | --- |
+| You still have your spend key | Instant Recovery: fast rekey, no clawback wait for the rekey itself. |
+| You lost your spend key (or cannot use it) | Timelocked Recovery: use your recovery phrase and wait for the clawback period before completing recovery. |
+| Your recovery key is compromised | Cancel any pending timelocked recovery with your spend key during the clawback window, then Instant Recovery to rotate to a new recovery key. |
+
+## Recovery clawback
+
+When a vault is created, you set a recovery clawback duration (a waiting period). If someone starts timelocked recovery, that timer must elapse before the recovery can finish. The delay gives the legitimate owner, who may still have the spend key, time to see an alert (for example by email) and cancel a malicious attempt. Instant Recovery does not replace this mechanism for the timelocked path; it is the fast path when the spend key is still yours.
+

--- a/docs/cloud-wallet/tooltips.md
+++ b/docs/cloud-wallet/tooltips.md
@@ -10,7 +10,7 @@ This page contains tooltip links from the Cloud Wallet. It provides some basic i
 
 ## Recovery
 
-This is the process of rekeying a vault. It will allow you to change any combination of your vault's spend key, recovery key, and recovery timelock. There are two types of recovery, explained in the following sections: Instant and Timelocked.
+This is the process of rekeying a vault. It will allow you to change any combination of your vault's spend key, recovery key, and recovery timelock. There are two types of recovery, explained in the following sections: Instant and Timelocked. More information about recovery is available on the [Recovery](/cloud-wallet/recovery) guide.
 
 ### Instant Recovery
 
@@ -50,7 +50,7 @@ If you use a BLS key as the recovery key, you will be given a series of 24 words
 
 ## Recovery Timer
 
-This is the amount of time you must wait before a recovery operation can be completed. The timer is set upon the vault’s creation, and it can only be modified during a recovery. For example, when you create a vault, if you set this timer to 3 days, then after you initiate a recovery, you will need to wait for 3 days to complete it. During that time, you can cancel the recovery. The reason this timer exists is so that if someone steals your recovery key, you can cancel any recovery attempts, and send your assets to a new vault.
+This is the amount of time you must wait before a recovery operation can be completed. The timer is set upon the vault’s creation, and it can only be modified during a recovery. For example, when you create a vault, if you set this timer to 3 days, then after you initiate a recovery, you will need to wait for 3 days to complete it. During that time, you can cancel the recovery. The reason this timer exists is so that if someone steals your recovery key, you can cancel recovery attempts during the window, then use Instant Recovery to rotate your recovery key while you still have your spend key. See the [Recovery](/cloud-wallet/recovery) guide.
 
 ## Signer App
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -186,6 +186,7 @@ module.exports = {
       items: [
         'cloud-wallet/getting-started',
         'cloud-wallet/buy-xch',
+        'cloud-wallet/recovery',
         'cloud-wallet/faq',
         'cloud-wallet/known-issues',
         'cloud-wallet/tooltips',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes that add and cross-link recovery guidance; low risk aside from potential user confusion if the described recovery flows are inaccurate.
> 
> **Overview**
> Adds a new `cloud-wallet/recovery` documentation page describing **Instant Recovery vs Timelocked Recovery**, including when to use each and how the recovery clawback window fits in.
> 
> Updates Cloud Wallet docs (`faq`, `getting-started`, and `tooltips`) and the Chia Signer getting-started guide to reference the new Recovery guide and clarify key-rotation scenarios (new phone, lost/compromised keys), and wires the new page into `sidebars.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00db82711ddbd9d1d432cfafc3240d89e668d8c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->