### PR TITLE
align dao, datalayer, and daemon RPC pages with reference

### DIFF
--- a/docs/reference-client/rpc-reference/daemon-rpc.md
+++ b/docs/reference-client/rpc-reference/daemon-rpc.md
@@ -7,7 +7,7 @@ slug: /reference-client/rpc-reference/daemon-rpc
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This document provides a comprehensive reference to Chia's Daemon RPC API.
+This document provides a comprehensive reference to Chia's Daemon RPC API over HTTPS/WebSockets (`chia/daemon/server.py`). Command names come from the daemon's command mapping (see `get_routes`). `chia rpc daemon` wraps these for local CLI use.
 
 <details>
   <summary>Note about Windows command escaping</summary>
@@ -166,7 +166,7 @@ Response:
 
 ### `get_routes`
 
-Functionality: List all available Daemon RPC routes
+Functionality: List all websocket command names exposed by the daemon (same set as `get_command_mapping()` in the daemon server).
 
 Usage: chia rpc daemon [OPTIONS] get_routes [REQUEST]
 
@@ -191,26 +191,27 @@ Response:
 ```json
 {
   "routes": [
-    "start_service",
-    "start_plotting",
-    "stop_plotting",
-    "stop_service",
-    "is_running",
-    "running_services",
-    "is_keyring_locked",
-    "keyring_status",
-    "unlock_keyring",
-    "validate_keyring_passphrase",
-    "set_keyring_passphrase",
-    "remove_keyring_passphrase",
     "exit",
-    "register_service",
-    "get_status",
-    "get_version",
+    "get_keys_for_plotting",
+    "get_network_info",
     "get_plotters",
     "get_routes",
+    "get_status",
+    "get_version",
     "get_wallet_addresses",
-    "get_keys_for_plotting"
+    "is_keyring_locked",
+    "is_running",
+    "keyring_status",
+    "register_service",
+    "remove_keyring_passphrase",
+    "running_services",
+    "set_keyring_passphrase",
+    "start_plotting",
+    "start_service",
+    "stop_plotting",
+    "stop_service",
+    "unlock_keyring",
+    "validate_keyring_passphrase"
   ],
   "success": true
 }

--- a/docs/reference-client/rpc-reference/dao-rpc.md
+++ b/docs/reference-client/rpc-reference/dao-rpc.md
@@ -15,9 +15,15 @@ Prior to using the DAO alpha primitive, be sure to read the [list of known issue
 
 :::
 
+:::info Removed from the reference client in Chia 2.5.3
+
+The proof-of-concept DAO wallet and all `dao_*` wallet RPCs were removed in [Chia blockchain 2.5.3](https://github.com/Chia-Network/chia-blockchain/blob/main/CHANGELOG.md#253-chia-blockchain-2025-03-25) (March 2025). Current releases do not register these commands on `chia rpc wallet get_routes`. The reference below is historical only.
+
+:::
+
 :::note
 
-The RPC to create a new DAO is a **wallet RPC** called [create_new_wallet](/reference-client/rpc-reference/wallet-rpc/#create_new_wallet), therefore it is not documented here. See Example 7 for details of how this command's options can be used.
+Creating a DAO wallet historically used the [create_new_wallet](/reference-client/rpc-reference/wallet-rpc/#create_new_wallet) wallet RPC (see Example 7). That flow applied to clients that still shipped the DAO wallet; it is not available on supported releases after the removal above.
 
 :::
 
@@ -40,7 +46,39 @@ chia rpc wallet dao_get_treasury_balance '{\"wallet_id\": 2}'
 
 </details>
 
-## Reference
+The sections below document **wallet** RPCs (`chia rpc wallet`) from when the DAO wallet still existed. On current releases, start from [Wallet RPC](/reference-client/rpc-reference/wallet-rpc); `chia rpc wallet get_routes` does not expose `dao_*` commands after the removal noted above.
+
+### `get_routes`
+
+Functionality: List every path on the wallet RPC server (`WalletRpcApi` plus shared `RpcServer` routes).
+
+Usage: chia rpc wallet [OPTIONS] get_routes [REQUEST]
+
+Options:
+
+| Short Command | Long Command | Type     | Required | Description                                                                           |
+| :------------ | :----------- | :------- | :------- | :------------------------------------------------------------------------------------ |
+| -j            | --json-file  | FILENAME | False    | Optionally instead of REQUEST you can provide a json file containing the request data |
+| -h            | --help       | None     | False    | Show a help message and exit                                                          |
+
+Request Parameters: None
+
+<details>
+<summary>Example</summary>
+
+```json
+chia rpc wallet get_routes
+```
+
+Response:
+
+The canonical sorted list is on [Wallet RPC — get_routes](/reference-client/rpc-reference/wallet-rpc#get_routes).
+
+</details>
+
+---
+
+## Historical reference (pre–DAO wallet removal)
 
 ### `dao_add_funds_to_treasury`
 

--- a/docs/reference-client/rpc-reference/datalayer-rpc.md
+++ b/docs/reference-client/rpc-reference/datalayer-rpc.md
@@ -28,7 +28,7 @@ chia rpc wallet create_new_wallet '{\"wallet_type\": \"nft_wallet\"}'
 
 ## Intro
 
-This page includes a comprehensive list of Chia's DataLayer RPC API.
+This page includes a comprehensive list of Chia's DataLayer RPC API. Routes implemented on `DataLayerRpcApi` are merged with the shared HTTP routes from `RpcServer` (connections, network info, version, logging, health checks, and graceful shutdown).
 
 We also have documented the [DataLayer CLI](/reference-client/cli-reference/datalayer-cli) commands for interacting with the DataLayer.
 
@@ -1471,9 +1471,9 @@ Response:
 
 ### `get_routes`
 
-Functionality: Show a comprehensive list of RPC routes for the DataLayer
+Functionality: List every HTTP path on the DataLayer RPC server (`DataLayerRpcApi` plus shared `RpcServer` routes).
 
-Usage: chia rpc data_layer [OPTIONS] get_routes
+Usage: chia rpc data_layer [OPTIONS] get_routes [REQUEST]
 
 Options:
 
@@ -1496,45 +1496,52 @@ Response:
 ```json
 {
   "routes": [
-    "/wallet_log_in",
-    "/create_data_store",
-    "/get_owned_stores",
-    "/batch_update",
-    "/submit_pending_root",
-    "/get_value",
-    "/get_keys",
-    "/get_keys_values",
-    "/get_ancestors",
-    "/get_root",
-    "/get_local_root",
-    "/get_roots",
-    "/delete_key",
-    "/insert",
-    "/subscribe",
-    "/unsubscribe",
     "/add_mirror",
-    "/delete_mirror",
-    "/get_mirrors",
-    "/remove_subscriptions",
-    "/subscriptions",
-    "/get_kv_diff",
-    "/get_root_history",
     "/add_missing_files",
-    "/make_offer",
-    "/take_offer",
-    "/verify_offer",
+    "/batch_update",
     "/cancel_offer",
-    "/get_sync_status",
     "/check_plugins",
     "/clear_pending_roots",
-    "/get_proof",
-    "/verify_proof",
-    "/get_connections",
-    "/open_connection",
     "/close_connection",
-    "/stop_node",
+    "/create_data_store",
+    "/delete_key",
+    "/delete_mirror",
+    "/get_ancestors",
+    "/get_connections",
+    "/get_keys",
+    "/get_keys_values",
+    "/get_kv_diff",
+    "/get_local_root",
+    "/get_log_level",
+    "/get_mirrors",
+    "/get_network_info",
+    "/get_owned_stores",
+    "/get_proof",
+    "/get_root",
+    "/get_root_history",
+    "/get_roots",
     "/get_routes",
-    "/healthz"
+    "/get_sync_status",
+    "/get_value",
+    "/get_version",
+    "/healthz",
+    "/insert",
+    "/make_offer",
+    "/multistore_batch_update",
+    "/open_connection",
+    "/remove_subscriptions",
+    "/reset_log_level",
+    "/set_log_level",
+    "/stop_node",
+    "/submit_all_pending_roots",
+    "/submit_pending_root",
+    "/subscribe",
+    "/subscriptions",
+    "/take_offer",
+    "/unsubscribe",
+    "/verify_offer",
+    "/verify_proof",
+    "/wallet_log_in"
   ],
   "success": true
 }


### PR DESCRIPTION
…client

DataLayer: document RpcServer merge, fix get_routes list (46 paths) including multistore/ submit_all/ log and version routes.
Daemon: add server.py context, include get_network_info in get_routes, sort route names.
DAO: note 2.5.3 removal, wallet get_routes, relabel command reference as historical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; main risk is confusing users if any route lists/descriptions still diverge from the actual RPC servers.
> 
> **Overview**
> Aligns the Daemon and DataLayer RPC reference pages with the reference client by clarifying how routes are exposed (websocket command mapping for the daemon; `DataLayerRpcApi` merged with shared `RpcServer` HTTP routes) and updating the documented `get_routes` output/usage accordingly.
> 
> Adds an explicit notice that the DAO wallet and `dao_*` wallet RPCs were removed in Chia 2.5.3, introduces a `wallet get_routes` pointer for current releases, and re-labels the remaining DAO RPC content as *historical reference*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add58b2e963a25d085ff6deb12683a22e246b94b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->