### PR TITLE
docs(cli): archive dao-cli for DAO wallet removal in 2.5.3

### DIFF
--- a/docs/reference-client/cli-reference/dao-cli.md
+++ b/docs/reference-client/cli-reference/dao-cli.md
@@ -7,17 +7,25 @@ slug: /reference-client/cli-reference/dao-cli
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This document contains a comprehensive reference of Chia DAO CLI commands and options.
+This page previously documented the `chia dao` command group for the proof-of-concept DAO wallet in older Chia clients.
 
-:::warning
+:::info Removed from the reference client in Chia 2.5.3
 
-Chia DAOs are currently an _alpha_ primitive. This means that DAOs are not yet ready for production use, but you can still test them on either a simulator or a testnet. **We recommend against creating DAOs with this primitive on mainnet!**
+The proof-of-concept DAO wallet and the **`chia dao`** CLI were removed in [Chia blockchain 2.5.3](https://github.com/Chia-Network/chia-blockchain/blob/main/CHANGELOG.md#253-chia-blockchain-2025-03-25) (March 2025). Current releases do not ship a `dao` subcommand on `chia -h`. The command reference below is **historical only** and does not apply to supported releases.
 
-Prior to using the DAO alpha primitive, be sure to read the [list of known issues](/dao-known-issues).
+For the same context on HTTP RPC, see [DAO RPC](/reference-client/rpc-reference/dao-rpc).
 
 :::
 
-## Reference
+:::warning
+
+The content below described an _alpha_ DAO primitive when it still existed. **Do not rely on it for current installs.**
+
+Prior discussion of known issues: [list of known issues](/dao-known-issues).
+
+:::
+
+## Historical reference (pre–DAO wallet removal)
 
 ## `add`
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it mainly adds deprecation/removed notices and re-labels the page to prevent readers from following unsupported CLI instructions.
> 
> **Overview**
> Updates the `DAO CLI` reference page to explicitly state that the proof-of-concept DAO wallet and `chia dao` command group were **removed in Chia 2.5.3**, and that the remaining command documentation is **historical only**.
> 
> Rewords the existing alpha warnings and renames the section header to **Historical reference**, with links to the corresponding `DAO RPC` page and prior known-issues discussion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18954541ce4382393fffe838667ec722896ba73f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->