### PR TITLE
docs(block-format): document FullBlock nested types and related protocol types

### DIFF
--- a/docs/chia-blockchain/consensus/block-validation/block-format.md
+++ b/docs/chia-blockchain/consensus/block-validation/block-format.md
@@ -10,18 +10,47 @@ on disk for the purpose of serving other nodes in the future.
 
 The FullBlock has fields for both the trunk and the foliage of the blockchain. The `header_hash`, which is used as the block identifier, is the hash of the `foliage` field in streamable format (see the [Serialization Protocol page](/chia-blockchain/protocol/serialization-protocol)). This commits to all relevant data and to all previous blocks.
 
-- **finished_sub_sots**: List[EndOfSubSlotBundle]: This contains all sub-slots that have been completed since the previous block in the chain (block `N-1`).
+- **finished_sub_slots**: List[EndOfSubSlotBundle]: This contains all sub-slots that have been completed since the previous block in the chain (block `N-1`).
 - **reward_chain_block**: RewardChainBlock: This is trunk data for the reward chain and challenge chain, including vdf outputs and proof of space.
-- **challenge_chain_sp_proof**: Optional[VDFProof]: Proof of the VDF for the challenge chain signage point, not provided for the first signage point, since that is and end of sub slot.
-- **challenge_chain_ip_proof** VDFProof: VDF proof from the previous cc infusion, up the infusion point.
-- **reward_chain_sp_proof**: Optional[VDFProof]: Proof of the VDF for the reward chain signage point, not provided for the first signage point, since that is and end of sub slot.
-- **reward_chain_ip_proof** VDFProof: VDF proof from the previous rc infusion, up to the infusion point.
+- **challenge_chain_sp_proof**: Optional[VDFProof]: Proof of the VDF for the challenge chain signage point, not provided for the first signage point, since that is an end of sub slot.
+- **challenge_chain_ip_proof**: VDFProof: VDF proof from the previous cc infusion, up the infusion point.
+- **reward_chain_sp_proof**: Optional[VDFProof]: Proof of the VDF for the reward chain signage point, not provided for the first signage point, since that is an end of sub slot.
+- **reward_chain_ip_proof**: VDFProof: VDF proof from the previous rc infusion, up to the infusion point.
 - **infused_challenge_chain_ip_proof**: Optional[VDFProof]: The ICC proof, only present if deficit < 16
 - **foliage**: Foliage: Foliage data for the reward chain block, the hash of this is the `header_hash`.
 - **foliage_transaction_block**: Optional[FoliageTransactionBlock]: Transaction related metadata that is relevant for light clients (not actual transactions), only for tx blocks.
 - **transactions_info**: Optional[TransactionsInfo]: Transaction related metadata that is not relevant for light clients (not actual transactions), only for tx blocks.
 - **transactions_generator**: Optional[SerializedProgram]: A clvm/rust program that generates all transactions (spends). See the next section for an important [update](#transactions_generator-update) due to the 2.1.0 hard fork.
 - **transactions_generator_ref_list**: List[uint32]: A list of block heights of previous generators referenced by this block's generator.
+
+### FullBlock nested streamable types (subtypes)
+
+In the protocol and RPC responses, `FullBlock` is one concrete streamable struct (implemented in `chia_rs`). Here “subtypes” means the nested streamable types below, not distinct inheritance subclasses.
+
+#### Transaction blocks versus non-transaction blocks
+
+Whether a `FullBlock` carries transactions is determined by `reward_chain_block.is_transaction_block`:
+
+- When that flag is false (not a transaction block), `foliage_transaction_block`, `transactions_info`, and `transactions_generator` are unset (`null` in JSON), and `transactions_generator_ref_list` is empty.
+- When it is true (a transaction block), those optional fields contain transaction-related metadata and the block generator program (see the next section for generator serialization).
+
+A JSON example of a non-transaction block is shown under [`get_block`](/reference-client/rpc-reference/full-node-rpc#get_block) in the full node RPC reference.
+
+#### What each nested type holds
+
+- `EndOfSubSlotBundle` (each element of `finished_sub_slots`): describes completed sub-slots between the previous block and this one.
+- `RewardChainBlock` (`reward_chain_block`): trunk data (height, weight, cumulative `total_iters`, signage index, proof of space, VDF outputs and related signatures, and `is_transaction_block`).
+- `Foliage` (`foliage`): chain linkage and farmer or pool layer (`prev_block_hash`, reward and pool targets, signatures, and hashes tying foliage to the trunk).
+- `FoliageTransactionBlock` (`foliage_transaction_block`, optional): light-client metadata for a transaction block (for example timestamp-related fields), not the spends themselves.
+- `TransactionsInfo` (`transactions_info`, optional): validation-oriented aggregates such as fees and cost associated with the generator.
+- `VDFProof` (each `*_proof` field): witness material for the corresponding VDF output where the protocol requires a proof.
+
+#### Related block-shaped protocol types
+
+Other consensus messages use similar building blocks but are not extra subclasses of `FullBlock`:
+
+- `UnfinishedBlock`: block still being assembled or propagated before it becomes a full block (see [`respond_unfinished_block`](/chia-blockchain/protocol/peer-protocol#respond_unfinished_block) in the peer protocol).
+- `HeaderBlock`: header material without the full transactions generator, used when a wallet asks the node for headers only (see [`respond_block_header`](/chia-blockchain/protocol/wallet-protocol#respond_block_header) in the wallet protocol).
 
 ## transactions_generator update
 


### PR DESCRIPTION
Clarify transaction vs non-transaction block fields, nested streamables, and HeaderBlock vs UnfinishedBlock. Fix field list typos (finished_sub_slots, an end of sub slot, VDF proof colons). Use backticks for identifiers, not bold.

Fixes https://github.com/Chia-Network/chia-docs/issues/29

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that clarify protocol structures and fix field-name/wording typos; no runtime or consensus logic is modified.
> 
> **Overview**
> Updates `block-format.md` to **fix typos/formatting** in the `FullBlock` field list (e.g., `finished_sub_slots` name, VDF proof entries, and wording around “end of sub slot”).
> 
> Adds a new section documenting **`FullBlock` nested streamable types**, including how transaction vs non-transaction blocks affect which optional fields are populated, brief descriptions of the nested structs, and pointers to related protocol types (`UnfinishedBlock`, `HeaderBlock`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75c41ca78746cbf2d3be28b6d32f5f85e45aedf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->