### PR TITLE
Upgrade to Node 24 and add min-release-age

### DIFF
--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   pull-from-crowdin:
     runs-on: [k8s-public]
-    container: node:20
+    container: node:24
     env:
       localization_branch_name: l10n_crowdin_translations
     steps:

--- a/.github/workflows/crowdin-push.yml
+++ b/.github/workflows/crowdin-push.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   push-to-crowdin:
     runs-on: [k8s-public]
-    container: node:20
+    container: node:24
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    container: node:20-alpine
+    container: node:24-alpine
     steps:
       - name: 'Install deps'
         run: |

--- a/.github/workflows/deploy-review.yml
+++ b/.github/workflows/deploy-review.yml
@@ -31,7 +31,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    container: node:20-alpine
+    container: node:24-alpine
     steps:
       - name: 'Install deps'
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=1

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=24.14.1"
   },
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Summary
- Upgrades Node.js requirement to 24.14.1+ (active LTS)
- Adds `min-release-age=1` to `.npmrc`, telling npm to only resolve package versions published more than 1 day ago
- Supply-chain-attack mitigation: malicious packages are typically flagged within hours, so a 1-day quarantine avoids installing freshly-published compromised versions
- Node 24 ships npm 11.10+, which is required for the `min-release-age` feature

## Test plan
- [ ] CI passes with Node 24
- [ ] `npm install` works correctly
- [ ] `npm ci` works correctly
- [ ] Application builds and runs successfully

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it upgrades the Node runtime used by CI workflows and raises the declared engine requirement, which can break builds or local dev if dependencies or tooling aren’t compatible with Node 24.
> 
> **Overview**
> **Upgrades the project and CI workflows to Node.js 24.** GitHub Actions jobs for Crowdin sync and site deploy/review builds now run in `node:24`/`node:24-alpine`, and `package.json` raises the supported engine to `>=24.14.1`.
> 
> **Adds npm supply-chain hardening.** Introduces `.npmrc` with `min-release-age=1` so installs avoid packages published within the last day.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f91b591f6953504036f77e0c167327c6d49faf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->