### PR TITLE
Clarify fee labels for testnets and mainnet in tooltips

### DIFF
--- a/docs/cloud-wallet/tooltips.md
+++ b/docs/cloud-wallet/tooltips.md
@@ -38,7 +38,11 @@ This key can only be used for recovering a vault. It cannot be used for signing 
 
 ## Transaction Fee
 
-A fee for speeding up your transaction’s confirmation time if the network is busy. Testnet11 is often being dusted with small transactions, so we recommend including a fee whenever possible. Typically 0.001 TXCH is sufficient for fast confirmation on testnet11.
+A fee for speeding up your transaction’s confirmation time if the network is busy.
+
+On mainnet, this fee is expressed in `XCH`. The recommended amount will depend on how busy the network is.
+
+On testnets, this fee is expressed in `TXCH`. A fee of 0.001 TXCH is often necessary -- and typically sufficient -- on these networks.
 
 ## Recovery Clawback
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates the **Transaction Fee** tooltip copy in `docs/cloud-wallet/tooltips.md` to split guidance by network instead of folding testnet11 dusting advice into one paragraph.
> 
> The intro now only states that fees speed confirmation when the network is busy. **Mainnet** fees are described in `XCH` with amounts depending on congestion. **Testnets** fees are described in `TXCH`, keeping the 0.001 TXCH guidance as often necessary and typically sufficient.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ccc59c2d051e56d83a87833cf55ba519fb7808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->