### PR TITLE
Docs/gaming alpha 2

### DIFF
--- a/docs/guides/chia-gaming/gaming-architecture.md
+++ b/docs/guides/chia-gaming/gaming-architecture.md
@@ -1,0 +1,151 @@
+---
+slug: /guides/gaming-architecture
+title: Architecture
+---
+
+This document explains the architecture and core concepts of the Chia Gaming system. Understanding these concepts is essential for developers building games or integrating with the platform.
+
+## System Overview
+
+The Chia Gaming system enables trustless two-player games using **state channels** on the Chia blockchain. Players lock funds into a shared on-chain coin, play the game entirely off-chain (fast, free, private), and settle the result back on-chain when done.
+
+The system consists of:
+
+- **Player App** — Static HTML/JS/CSS/WASM application that runs entirely in the browser. Contains the WASM game engine, game UIs, and the code that talks to a blockchain interface.
+- **Tracker** — A lobby and WebSocket relay service. Provides matchmaking and ferries game messages between peers. Trackers are third-party code; anyone can run one.
+- **Chia wallet (live play)** — Connected via WalletConnect. The player app reads chain state and submits transactions through the wallet (for example `chia_getCoinRecordsByNames`, `chia_pushTransactions`). A full node on the same machine is not required for players; the wallet handles chain interaction.
+- **Simulator (development)** — Optional local service (`chia-gaming-sim`, ports 5800/5801) used instead of WalletConnect when testing without real XCH. Configured in `front-end/src/settings.ts`.
+
+## State Channels
+
+A state channel is a mechanism that allows two parties to transact off-chain while retaining on-chain security guarantees. The general flow is:
+
+1. **Open**: Both players fund a shared on-chain coin (the "channel coin")
+2. **Play**: Game moves happen off-chain, with each state update signed by both parties
+3. **Close**: The final state is settled on-chain, distributing funds according to the game outcome
+
+The key insight is that either party can unilaterally close the channel at any time by posting the latest agreed-upon state to the blockchain. This means neither player needs to trust the other — if one party disappears or misbehaves, the other can always recover their funds.
+
+## Coin Hierarchy
+
+The on-chain state is represented by a hierarchy of coins (simplified; see `OVERVIEW.md` in the chia-gaming repository for the full tree including per-player funding coins and the launcher):
+
+```
+Funding coins (one per player) → launcher → Channel Coin
+    → Unroll Coin → reward coins and/or Game Coins (referee puzzle)
+```
+
+- **Channel Coin**: Holds the channel funds after the handshake. Controlled by a 2-of-2 aggregate key; off-chain play updates signed unroll commitments without moving the channel coin until shutdown or dispute.
+- **Unroll Coin**: Represents the latest mutually-agreed state with a sequence number. A higher sequence number preempts a lower one during dispute resolution.
+- **Game coins**: Created when a game starts within the channel. Each is governed by a referee puzzle (Chialisp) for that game type; on-chain moves are validated against that puzzle if a dispute is forced.
+
+## The Potato Protocol
+
+The "potato" is a conceptual token that alternates between players, determining whose turn it is to act. The protocol ensures:
+
+- Only one player can propose a state update at a time
+- Each state update increments a sequence number
+- Both players sign each state transition
+- The latest signed state is always available for on-chain settlement
+
+The name comes from "hot potato" — you hold it when it's your turn, and pass it when you've made your move. The potato carries:
+
+- The current game state
+- The sequence number
+- Signatures from both parties on the previous state
+- The proposed next state (unsigned by the receiver until they accept)
+
+## Referee Pattern
+
+Each game type implements a **referee** — a Chialisp puzzle that can validate game moves on-chain. During normal play, the referee is never invoked because both players agree on the game state. However, if a dispute arises:
+
+1. Either player posts the game state on-chain
+2. The referee puzzle validates each subsequent move
+3. After a timeout or game completion, the referee distributes funds
+
+The referee ensures that even if the off-chain communication breaks down, the game can always be completed fairly on-chain (albeit more slowly and at transaction cost).
+
+### Game Handlers
+
+Each game implements a **handler** — Rust code that manages the game logic off-chain. Handlers are responsible for:
+
+- Validating incoming moves from the opponent
+- Computing the next game state
+- Generating the appropriate Chialisp evidence for on-chain validation (if needed)
+- Managing game-specific state (cards, boards, scores)
+
+The handler architecture allows new games to be added without modifying the core channel infrastructure.
+
+## Connection Types
+
+Per the connectivity model in the chia-gaming repository (`CONNECTIVITY.md`), the **blockchain itself is not a connection**; it is the ground truth. What you connect to in the player app are three operational axes plus session state:
+
+| Axis    | Purpose                                     | How it is reached                          |
+| ------- | ------------------------------------------- | ------------------------------------------ |
+| Wallet  | Sign spends, read balances and coin records | WalletConnect (live) or simulator (dev)    |
+| Tracker | Lobby UI (iframe) and message relay         | WebSocket to the tracker you joined        |
+| Peer    | Opponent game traffic                       | Relayed over the tracker's WebSocket       |
+| Session | In-progress channel obligation              | Local state + on-chain coins; not a socket |
+
+### Session Rollover
+
+Session state (channel progress, pairing token, and related data) is stored in browser `localStorage`. The **tracker** connection can auto-reconnect with backoff after transient outages (`CONNECTIVITY.md`). There is no guaranteed “reconnect to the same peer” after a hard disconnect; both players may need to re-match on a tracker. Clearing browser storage loses the session. Wallet disconnect stalls signing until the wallet is reconnected; the session obligation on-chain remains.
+
+### Tracker Availability
+
+The tracker is only required for:
+
+- Initial matchmaking (creating/joining rooms)
+- Relaying messages between peers during gameplay
+
+It is **not** required for on-chain settlement. If the tracker disappears permanently, players can still close the channel on-chain using their locally-stored state.
+
+## WalletConnect Integration
+
+The player app communicates with the Chia wallet via WalletConnect using the `chia` namespace. The following methods are used:
+
+| Method                       | Purpose                                           |
+| ---------------------------- | ------------------------------------------------- |
+| `chia_getWallets`            | List available wallets                            |
+| `chia_getWalletBalance`      | Check available balance                           |
+| `chia_getNextAddress`        | Get a receive address                             |
+| `chia_getHeightInfo`         | Get current blockchain height                     |
+| `chia_selectCoins`           | Select coins for channel funding                  |
+| `chia_createOfferForIds`     | Create offers (used in channel open)              |
+| `chia_pushTransactions`      | Push signed transactions to the mempool           |
+| `chia_createNewRemoteWallet` | Create a remote wallet for tracking channel coins |
+| `chia_registerRemoteCoins`   | Register channel coins for observation            |
+| `chia_getCoinRecordsByNames` | Look up specific coin records                     |
+| `chia_getPuzzleAndSolution`  | Get puzzle/solution for spent coins               |
+
+## Security Model
+
+The security of the system rests on several guarantees:
+
+1. **Unilateral close**: Either player can always close the channel on-chain
+2. **Latest state wins**: Higher sequence numbers always supersede lower ones
+3. **Timeout protection**: If one player disappears during an on-chain dispute, the other can claim funds after a timeout
+4. **Tracker is a relay, not a co-signer**: The tracker ferries lobby and game messages; it does not hold channel keys or settle balances. Players still rely on signed off-chain state and on-chain puzzles for security.
+5. **Wallet isolation**: The player app never has access to private keys; all signing happens in the wallet via WalletConnect
+
+## Frontend Architecture
+
+The frontend is split into two separately-deployed applications:
+
+### Player App
+
+- Fully static (HTML/JS/CSS/WASM) — no server-side logic
+- Contains the WASM game engine compiled from Rust
+- Handles WalletConnect integration
+- Manages game state in browser localStorage
+- Loads the tracker's lobby UI in an iframe
+
+### Tracker (Lobby + Relay)
+
+- Express + WebSocket service
+- Serves the lobby UI (room creation, matchmaking)
+- Relays game messages between connected peers
+- Loaded inside an iframe within the player app
+- Must be on a **different origin** from the player app (security boundary)
+
+This separation ensures that the tracker (which is third-party code) cannot access the player app's WalletConnect session or game state.

--- a/docs/guides/chia-gaming/gaming-architecture.md
+++ b/docs/guides/chia-gaming/gaming-architecture.md
@@ -11,10 +11,10 @@ The Chia Gaming system enables trustless two-player games using **state channels
 
 The system consists of:
 
-- **Player App** — Static HTML/JS/CSS/WASM application that runs entirely in the browser. Contains the WASM game engine, game UIs, and the code that talks to a blockchain interface.
-- **Tracker** — A lobby and WebSocket relay service. Provides matchmaking and ferries game messages between peers. Trackers are third-party code; anyone can run one.
-- **Chia wallet (live play)** — Connected via WalletConnect. The player app reads chain state and submits transactions through the wallet (for example `chia_getCoinRecordsByNames`, `chia_pushTransactions`). A full node on the same machine is not required for players; the wallet handles chain interaction.
-- **Simulator (development)** — Optional local service (`chia-gaming-sim`, ports 5800/5801) used instead of WalletConnect when testing without real XCH. Configured in `front-end/src/settings.ts`.
+- **Player App**: Static HTML/JS/CSS/WASM application that runs entirely in the browser. Contains the WASM game engine, game UIs, and the code that talks to a blockchain interface.
+- **Tracker**: A lobby and WebSocket relay service. Provides matchmaking and ferries game messages between peers. Trackers are third-party code; anyone can run one.
+- **Chia wallet (live play)**: Connected via WalletConnect. The player app reads chain state and submits transactions through the wallet (for example `chia_getCoinRecordsByNames`, `chia_pushTransactions`). A full node on the same machine is not required for players; the wallet handles chain interaction.
+- **Simulator (development)**: Optional local service (`chia-gaming-sim`, ports 5800/5801) used instead of WalletConnect when testing without real XCH. Configured in `front-end/src/settings.ts`.
 
 ## State Channels
 
@@ -24,7 +24,7 @@ A state channel is a mechanism that allows two parties to transact off-chain whi
 2. **Play**: Game moves happen off-chain, with each state update signed by both parties
 3. **Close**: The final state is settled on-chain, distributing funds according to the game outcome
 
-The key insight is that either party can unilaterally close the channel at any time by posting the latest agreed-upon state to the blockchain. This means neither player needs to trust the other — if one party disappears or misbehaves, the other can always recover their funds.
+The key insight is that either party can unilaterally close the channel at any time by posting the latest agreed-upon state to the blockchain. This means neither player needs to trust the other; if one party disappears or misbehaves, the other can always recover their funds.
 
 ## Coin Hierarchy
 
@@ -48,7 +48,7 @@ The "potato" is a conceptual token that alternates between players, determining 
 - Both players sign each state transition
 - The latest signed state is always available for on-chain settlement
 
-The name comes from "hot potato" — you hold it when it's your turn, and pass it when you've made your move. The potato carries:
+The name comes from "hot potato": you hold it when it's your turn, and pass it when you've made your move. The potato carries:
 
 - The current game state
 - The sequence number
@@ -57,7 +57,7 @@ The name comes from "hot potato" — you hold it when it's your turn, and pass i
 
 ## Referee Pattern
 
-Each game type implements a **referee** — a Chialisp puzzle that can validate game moves on-chain. During normal play, the referee is never invoked because both players agree on the game state. However, if a dispute arises:
+Each game type implements a **referee**: a Chialisp puzzle that can validate game moves on-chain. During normal play, the referee is never invoked because both players agree on the game state. However, if a dispute arises:
 
 1. Either player posts the game state on-chain
 2. The referee puzzle validates each subsequent move
@@ -67,7 +67,7 @@ The referee ensures that even if the off-chain communication breaks down, the ga
 
 ### Game Handlers
 
-Each game implements a **handler** — Rust code that manages the game logic off-chain. Handlers are responsible for:
+Each game implements a **handler**: Rust code that manages the game logic off-chain. Handlers are responsible for:
 
 - Validating incoming moves from the opponent
 - Computing the next game state
@@ -118,6 +118,10 @@ The player app communicates with the Chia wallet via WalletConnect using the `ch
 | `chia_getCoinRecordsByNames` | Look up specific coin records                     |
 | `chia_getPuzzleAndSolution`  | Get puzzle/solution for spent coins               |
 
+### Channel open (handshake)
+
+Opening a channel uses **one** on-chain spend bundle, but each wallet still goes through **several** WalletConnect steps during the A–F handshake (for example `chia_selectCoins`, two `chia_createOfferForIds` calls, one per player’s funding share, and `chia_pushTransactions`). Approve each request in the Chia wallet; a missing approval can make the handshake look stuck even though only one transaction is submitted on chain.
+
 ## Security Model
 
 The security of the system rests on several guarantees:
@@ -134,7 +138,7 @@ The frontend is split into two separately-deployed applications:
 
 ### Player App
 
-- Fully static (HTML/JS/CSS/WASM) — no server-side logic
+- Fully static (HTML/JS/CSS/WASM): no server-side logic
 - Contains the WASM game engine compiled from Rust
 - Handles WalletConnect integration
 - Manages game state in browser localStorage

--- a/docs/guides/chia-gaming/gaming-architecture.md
+++ b/docs/guides/chia-gaming/gaming-architecture.md
@@ -63,7 +63,7 @@ Each game type implements a **referee**: a Chialisp puzzle that can validate gam
 2. The referee puzzle validates each subsequent move
 3. After a timeout or game completion, the referee distributes funds
 
-The referee ensures that even if the off-chain communication breaks down, the game can always be completed fairly on-chain (albeit more slowly and at transaction cost).
+The referee ensures that even if the off-chain communication breaks down, the game can always be completed fairly, on-chain (albeit more slowly and at transaction cost).
 
 ### Game Handlers
 

--- a/docs/guides/chia-gaming/gaming-california-poker-rules.md
+++ b/docs/guides/chia-gaming/gaming-california-poker-rules.md
@@ -3,6 +3,12 @@ slug: /guides/gaming-california-poker-rules
 title: California Poker Rules
 ---
 
+:::note Early Alpha Release
+
+California Poker (CalPoker) is available in Alpha 2. On-chain Chialisp, rules, and UI may change as development continues.
+
+:::
+
 ## Objective
 
 California Poker is a card game where players exchange cards and compete to make the best five-card poker hand. Each player receives 8 cards with all 16 cards visible to both players, selects 4 to swap with the other player, and keeps the other 4. The player who can make the best five-card poker hand from their 8 cards after swapping wins.

--- a/docs/guides/chia-gaming/gaming-developers-guide.md
+++ b/docs/guides/chia-gaming/gaming-developers-guide.md
@@ -19,13 +19,13 @@ This is an **alpha release** of the Chia Gaming system. The codebase is subject 
 
 This guide covers the development, testing, and deployment process for the Chia Gaming system. The system consists of two deployable artifacts:
 
-1. **Player App** — A fully static HTML/JS/CSS/WASM application that players run in their browser. It contains the wallet connection, WASM game engine, and all game UIs. No server-side logic, no cookies, no server-side sessions.
-2. **Tracker** — A separate service that provides a lobby UI (loaded as an iframe inside the player app) and a WebSocket relay that ferries game messages between peers. Trackers are third-party code — anyone can run one.
+1. **Player App**: A fully static HTML/JS/CSS/WASM application that players run in their browser. It contains the wallet connection, WASM game engine, and all game UIs. No server-side logic, no cookies, no server-side sessions.
+2. **Tracker**: A separate service that provides a lobby UI (loaded as an iframe inside the player app) and a WebSocket relay that ferries game messages between peers. Trackers are third-party code; anyone can run one.
 
 To follow this guide, you will need:
 
 - Linux or macOS operating system
-- Rust (stable) with the `wasm32-unknown-unknown` target
+- Rust (stable; pinned in the repo’s `rust-toolchain.toml`) with the `wasm32-unknown-unknown` target
 - Node.js 20+ and pnpm 10.33+
 - wasm-pack 0.13.1
 - Chia wallet **2.7.1 or later** (required minimum for Alpha 2; earlier wallet versions are not supported)
@@ -50,7 +50,7 @@ For information about becoming a gaming partner, see the [Gaming Partner RFP](/g
 ### Developer Dependencies
 
 - **Operating System**: Linux or macOS
-- **Rust** (stable) with `wasm32-unknown-unknown` target:
+- **Rust** (stable) with `wasm32-unknown-unknown` target: the [chia-gaming `rust-toolchain.toml`](https://github.com/Chia-Network/chia-gaming/blob/main/rust-toolchain.toml) pins the channel and targets when you build from a clone:
   ```bash
   rustup target add wasm32-unknown-unknown
   ```
@@ -99,8 +99,8 @@ cd chia-gaming
 
 Flags:
 
-- `--skip-build` — skip all build steps, use existing artifacts
-- `--force-build` — `cargo clean` before building
+- `--skip-build`: skip all build steps, use existing artifacts
+- `--force-build`: `cargo clean` before building
 
 Press Ctrl-C to stop all services.
 
@@ -110,8 +110,8 @@ Press Ctrl-C to stop all services.
 
 **Alpha 2 binaries:** Download from the [chia-gaming Releases](https://github.com/Chia-Network/chia-gaming/releases) page on the Alpha 2 release tag. Those assets are the **staged** archives from `tools/build-deploy.sh` (`.zip` and `.tgz` with the same contents):
 
-- `chia-gaming-YYYYMMDD-HASH.zip` — player app (`index.html`, `build-meta.json`, `app/<nonce>/` with JS, CSS, WASM, and `clsp/`)
-- `chia-gaming-lobby-YYYYMMDD-HASH.zip` — tracker (same staging layout, plus `service.js` at the archive root)
+- `chia-gaming-YYYYMMDD-HASH.zip`: player app (`index.html`, `build-meta.json`, `app/<nonce>/` with JS, CSS, WASM, and `clsp/`)
+- `chia-gaming-lobby-YYYYMMDD-HASH.zip`: tracker (same staging layout, plus `service.js` at the archive root)
 
 Build them yourself with `./tools/build-deploy.sh` from source (see [DEPLOYING.md](https://github.com/Chia-Network/chia-gaming/blob/main/DEPLOYING.md)). The staged layout matches what `run-local-demo.sh` assembles locally (file copies under `front-end/serve` and `lobby/lobby-frontend/serve`).
 
@@ -128,10 +128,10 @@ For production packaging or partial rebuilds. Run commands from the repo root. T
 **1. Chialisp (.hex files):**
 
 ```bash
-find clsp -name '*.hex' -delete
-cp build.rs.disabled build.rs
-cargo build
+./tools/build-chialisp.sh
 ```
+
+This script clears stale `.hex` files, enables the Rust build script, and compiles all `.clsp` sources, the same step `run-local-demo.sh` uses.
 
 **2. WASM (browser target):**
 
@@ -247,7 +247,7 @@ Key points:
 
 - The player app and tracker must be served from **different origins** (the lobby loads inside an iframe)
 - WASM files and `.hex` chialisp files must be under the same `basePath` as `index.js`
-- No simulator in production — players connect their Chia wallet via WalletConnect
+- No simulator in production: players connect their Chia wallet via WalletConnect
 - Use `tools/build-deploy.sh` to produce deployment zip archives (see [DEPLOYING.md](https://github.com/Chia-Network/chia-gaming/blob/main/DEPLOYING.md))
 
 ## Manual Configuration
@@ -256,8 +256,8 @@ Key points:
 
 **Alpha 2 supports mainnet only.** The player app is wired for mainnet in source:
 
-- `front-end/src/constants/env.ts` — `CHAIN_ID = 'chia:mainnet'`
-- `src/common/constants.rs` — `AGG_SIG_ME_ADDITIONAL_DATA` is the mainnet value
+- `front-end/src/constants/env.ts`: `CHAIN_ID = 'chia:mainnet'`
+- `src/common/constants.rs`: `AGG_SIG_ME_ADDITIONAL_DATA` is the mainnet value
 
 There is no supported testnet configuration for Alpha 2. Use the **simulator** (`run-local-demo.sh`) for development without mainnet XCH. Do not change these constants for testnet unless you are doing unsupported custom experimentation.
 
@@ -269,8 +269,8 @@ The repository ships a default WalletConnect **Project ID** in `front-end/src/co
 
 Once you have your Project ID, update:
 
-1. **Project ID**: `front-end/src/constants/env.ts` — update `PROJECT_ID` (and `RELAY_URL` if needed)
-2. **Chain and methods**: `front-end/src/constants/wallet-connect.ts` — update `REQUIRED_NAMESPACES` / `ChiaMethod` if the wallet API changes (must match what the player app calls in `RealBlockchainInterface.ts`)
+1. **Project ID**: `front-end/src/constants/env.ts`: update `PROJECT_ID` (and `RELAY_URL` if needed)
+2. **Chain and methods**: `front-end/src/constants/wallet-connect.ts`: update `REQUIRED_NAMESPACES` / `ChiaMethod` if the wallet API changes (must match what the player app calls in `RealBlockchainInterface.ts`)
 
 ### Port Configuration
 

--- a/docs/guides/chia-gaming/gaming-developers-guide.md
+++ b/docs/guides/chia-gaming/gaming-developers-guide.md
@@ -9,34 +9,39 @@ This is an **alpha release** of the Chia Gaming system. The codebase is subject 
 
 :::
 
-:::danger Funds Left On-Chain
+<!-- Legacy anchors preserved for external links -->
 
-**When using a live WalletConnect instance, funds will be left on-chain after shutdown.** Upon shutdown, a new game is created, leading to one game's worth of funds being left on-chain and not returned to users. For example, if the game stake is 10 mojo, then 10 mojos will remain on-chain after shutting down the session (once per lobby not per game). **Use the simulator for development to avoid this issue. This is a high priority issue which we are working to fix ASAP.**
-
-:::
-
-:::note Easy Developer Config Coming Soon
-
-The easy developer configuration is still in development. Currently, parameters need to be manually coded. See the [Manual Configuration](#manual-configuration) section below for details.
-
-:::
+<span id="setup-and-build"></span>
+<span id="running-individual-services"></span>
+<span id="ports-and-domain-updates"></span>
 
 ## Intro
 
-This guide covers the development, testing, and deployment process for the Chia Gaming system. The system consists of two Docker images: the lobby server and the game code server.
+This guide covers the development, testing, and deployment process for the Chia Gaming system. The system consists of two deployable artifacts:
+
+1. **Player App** — A fully static HTML/JS/CSS/WASM application that players run in their browser. It contains the wallet connection, WASM game engine, and all game UIs. No server-side logic, no cookies, no server-side sessions.
+2. **Tracker** — A separate service that provides a lobby UI (loaded as an iframe inside the player app) and a WebSocket relay that ferries game messages between peers. Trackers are third-party code — anyone can run one.
 
 To follow this guide, you will need:
 
-- Linux operating system
-- Docker (latest version recommended)
-- Chia 2.5.7 (for WalletConnect testing)
+- Linux or macOS operating system
+- Rust (stable) with the `wasm32-unknown-unknown` target
+- Node.js 20+ and pnpm 10.33+
+- wasm-pack 0.13.1
+- Chia wallet **2.7.1 or later** (required minimum for Alpha 2; earlier wallet versions are not supported)
 - Access to the [chia-gaming repository](https://github.com/Chia-Network/chia-gaming)
+
+:::note Alpha 2 games
+
+**California Poker** and **Space Poker** are playable in Alpha 2 as early releases; on-chain Chialisp, rules, and UI may change. **Krunk** is not yet available in the player app.
+
+:::
 
 For game rules and mechanics, see:
 
 - [California Poker Rules](/guides/gaming-california-poker-rules)
-- [Space Poker Rules](/guides/gaming-space-poker-rules) (coming soon)
-- [Krunk Rules](/guides/gaming-krunk-rules) (coming soon)
+- [Space Poker Rules](/guides/gaming-space-poker-rules)
+- [Krunk Rules](/guides/gaming-krunk-rules)
 
 For information about becoming a gaming partner, see the [Gaming Partner RFP](/guides/gaming-partner-rfp).
 
@@ -44,87 +49,130 @@ For information about becoming a gaming partner, see the [Gaming Partner RFP](/g
 
 ### Developer Dependencies
 
-- **Operating System**: Linux
-- **Containerization**: Docker (latest version recommended)
-- **Chia Wallet**: Chia 2.5.7 (only needed for live WalletConnect testing/playthroughs, not required for simulator testing)
-- **Codebase**: Access to the [chia-gaming repository](https://github.com/Chia-Network/chia-gaming) or the [Docker images](https://github.com/Chia-Network/chia-gaming/releases)
-- **Testing (Optional)**: Firefox or Chrome, and their respective Selenium drivers for running automated tests
+- **Operating System**: Linux or macOS
+- **Rust** (stable) with `wasm32-unknown-unknown` target:
+  ```bash
+  rustup target add wasm32-unknown-unknown
+  ```
+- **wasm-pack** 0.13.1:
+  ```bash
+  cargo install wasm-pack --version 0.13.1
+  ```
+- **Node.js 20+** and **pnpm 10.33+**:
+  ```bash
+  corepack enable
+  corepack prepare pnpm@10.33.0 --activate
+  ```
+- **macOS only**: Homebrew LLVM for WASM builds (`brew install llvm`). Build scripts automatically detect and use it.
+- **Chia Wallet**: Chia **2.7.1 or later** (required minimum for Alpha 2; only needed for live WalletConnect testing, not required for simulator testing)
+- **Codebase**: Access to the [chia-gaming repository](https://github.com/Chia-Network/chia-gaming) or the release artifacts
 
 ### User Dependencies
 
-- **Chia Wallet**: Chia 2.5.7 (light wallet, full node not required)
-- **Blockchain Data**: The backend connects to coinset.org for blockchain data. Users' wallets perform transaction spends via WalletConnect. Both services are required for gameplay.
+- **Chia wallet**: **2.7.1 or later** (required minimum for Alpha 2; light wallet is sufficient; a local full node is not required for players)
+- **WalletConnect (live play)**: Each player connects their wallet via WalletConnect. The player app uses wallet RPC methods (for example `chia_getCoinRecordsByNames`, `chia_pushTransactions`) through that connection (`front-end/src/hooks/RealBlockchainInterface.ts`).
+- **Simulator (development)**: For testing without real XCH, use simulator mode and the `chia-gaming-sim` binary started by `run-local-demo.sh` (HTTP port 5800, WebSocket port 5801; see `front-end/src/settings.ts`).
 
 :::tip Common Issues
 
-For common setup issues and solutions (Docker version, permissions, etc.), see the [Known Issues](/guides/gaming-known-issues) document.
+For common setup issues and solutions, see the [Known Issues](/guides/gaming-known-issues) document.
 
 :::
 
 ## Development Workflow
 
-### Setup and Build
+### Quick Start (Local Demo)
 
-1. **Get the Codebase**: Choose one of the following options:
+The fastest way to get started is `run-local-demo.sh`, which builds everything (including `tools/build-chialisp.sh` and a `--dev` WASM build for faster iteration) and starts three services:
 
-   **Option A: Clone the Repository**:
+```bash
+git clone https://github.com/Chia-Network/chia-gaming.git
+cd chia-gaming
+./run-local-demo.sh
+```
 
-   ```bash
-   git clone https://github.com/Chia-Network/chia-gaming.git
-   cd chia-gaming
-   ```
+| Service    | Default URL                                                       | Override env var          |
+| ---------- | ----------------------------------------------------------------- | ------------------------- |
+| Player app | `http://localhost:3002`                                           | `GAME_PORT`               |
+| Tracker    | `http://localhost:3003`                                           | `TRACKER_PORT`            |
+| Simulator  | `http://localhost:5800` (HTTP), `ws://localhost:5801` (WebSocket) | `SIM_PORT`, `SIM_WS_PORT` |
 
-   **Option B: Use Docker Images from Releases**:
-   Download the Docker images from the [chia-gaming releases page](https://github.com/Chia-Network/chia-gaming/releases).
+Flags:
 
-2. **Install Dependencies**: Ensure all developer dependencies (Linux, Docker, Chia 2.5.7) are installed and configured.
+- `--skip-build` — skip all build steps, use existing artifacts
+- `--force-build` — `cargo clean` before building
 
-3. **Manual Configuration (Optional)**: If you need to customize network settings, WalletConnect project info, ports, or domain, see the [Manual Configuration](#manual-configuration) section below.
+Press Ctrl-C to stop all services.
 
-4. **Build Docker Images**:
+### Using Release Artifacts
 
-   ```bash
-   ./build-docker-images.sh
-   ```
+**Local development:** `./run-local-demo.sh` builds everything, assembles the nonce-based staging trees (`build-meta.json`, assets under `app/<nonce>/`), and starts the player app, tracker, and simulator.
 
-   This command automatically configures both Docker images, compiles any new code within those images, and then launches both the lobby server and game code server.
+**Alpha 2 binaries:** Download from the [chia-gaming Releases](https://github.com/Chia-Network/chia-gaming/releases) page on the Alpha 2 release tag. Those assets are the **staged** archives from `tools/build-deploy.sh` (`.zip` and `.tgz` with the same contents):
 
-   :::note Port Configuration
+- `chia-gaming-YYYYMMDD-HASH.zip` — player app (`index.html`, `build-meta.json`, `app/<nonce>/` with JS, CSS, WASM, and `clsp/`)
+- `chia-gaming-lobby-YYYYMMDD-HASH.zip` — tracker (same staging layout, plus `service.js` at the archive root)
 
-   Ports are manually coded in the `build-docker-images.sh` and `run-docker-demo.sh` scripts. The default ports are:
-   - **Port 3000**: Frontend web interface (game UI)
-   - **Port 3001**: Lobby server API
-   - **Port 5800**: Simulator service
+Build them yourself with `./tools/build-deploy.sh` from source (see [DEPLOYING.md](https://github.com/Chia-Network/chia-gaming/blob/main/DEPLOYING.md)). The staged layout matches what `run-local-demo.sh` assembles locally (file copies under `front-end/serve` and `lobby/lobby-frontend/serve`).
 
-   To change ports, edit these scripts directly.
+To run the tracker from a release zip:
 
-   :::
+```bash
+PORT=3003 node service.js --self 'https://your-tracker.example' --dir /path/to/extracted-lobby-archive
+```
 
-5. **Run Docker Images** (if not automatically started):
+### Building Step by Step
 
-   ```bash
-   ./run-docker-demo.sh
-   ```
+For production packaging or partial rebuilds. Run commands from the repo root. The full sequence is documented in [DEPLOYING.md](https://github.com/Chia-Network/chia-gaming/blob/main/DEPLOYING.md) and mirrored in `tools/build-deploy.sh`.
 
-   Note: The build command automatically runs this once complete.
+**1. Chialisp (.hex files):**
+
+```bash
+find clsp -name '*.hex' -delete
+cp build.rs.disabled build.rs
+cargo build
+```
+
+**2. WASM (browser target):**
+
+```bash
+cd wasm && wasm-pack build --out-dir=../front-end/dist --release --target=web
+```
+
+For development, use `--dev` instead of `--release` (faster builds, larger output).
+
+**3. Player app (frontend JS/CSS):**
+
+```bash
+cd front-end && pnpm install --frozen-lockfile && pnpm run build
+```
+
+**4. Lobby frontend:**
+
+```bash
+cd lobby && pnpm install --frozen-lockfile
+pnpm --filter chia-gaming-lobby-frontend run build
+```
+
+If `pnpm install` in `lobby/` warns about ignored build scripts, that is expected (see [Known Issues](/guides/gaming-known-issues)). `tools/build-deploy.sh` uses `pnpm install --frozen-lockfile --ignore-scripts` in `lobby/` for production builds.
+
+**5. Lobby service:**
+
+```bash
+cd lobby && pnpm --filter chia-gaming-lobby-service run build
+```
+
+**6. Simulator (development only):**
+
+```bash
+cargo build --features sim-server --bin chia-gaming-sim
+```
 
 ### Making Code Changes
 
-:::note Repository Required
-
-To make code changes, you must have cloned the repository (Option A from the Setup and Build section). Code changes cannot be made when using Docker images from releases (Option B).
-
-:::
-
 1. **Edit Source Code**: Make your changes to the codebase.
 
-2. **Rebuild Docker Images**: After making changes, rebuild the Docker images:
-
-   ```bash
-   ./build-docker-images.sh
-   ```
-
-   This will recompile your changes and restart the services.
+2. **Rebuild**: After making changes, rebuild the affected components. For quick iteration, use `--skip-build` with `run-local-demo.sh` if you only changed frontend code, or rebuild individual steps as needed.
 
 3. **Test Changes**: Use the simulator (recommended) or live WalletConnect to test your modifications.
 
@@ -132,184 +180,111 @@ To make code changes, you must have cloned the repository (Option A from the Set
 
 :::note Simulator Recommended
 
-For development, it is recommended to use the simulator for testing game logic without interacting with a real WalletConnect instance.
+For development, it is recommended to use the simulator for testing game logic without interacting with a real Chia wallet.
 
 :::
 
 **Using Simulator (Recommended for Development):**
 
-1. Navigate to the game server URL (typically `http://localhost:3000`)
-2. Enable the simulator option in the UI
-3. Create a room and copy the generated room link
-4. Open a different web browser, user profile, or incognito/private window
-5. Paste the room link to join as the second player using the simulator
+1. Start the local demo with `./run-local-demo.sh`
+2. Navigate to the player app URL (`http://localhost:3002`)
+3. Enable the simulator option in the UI
+4. Create a room and copy the generated room link
+5. Open a different web browser, user profile, or incognito/private window
+6. Paste the room link to join as the second player using the simulator
 
 **Using Live WalletConnect (Advanced Testing):**
 
-:::danger Funds Left On-Chain
-
-**When using a live WalletConnect instance, funds will be left on-chain after shutdown.** Upon shutdown, a new game is created, leading to one game's worth of funds being left on-chain and not returned to users. For example, if the game stake is 10 mojo, then 10 mojos will remain on-chain after shutting down the session (once per lobby not per game). **Use the simulator for development to avoid this issue. This is a high priority issue which we are working to fix ASAP.**
-
-:::
-
 :::important Two Separate Wallet Instances Required
 
-When testing with live WalletConnect (not simulator), you **must** use two different Chia wallet instances. You cannot use the same wallet or installation for both players. The easiest approach is to deploy the gaming system to a URL accessible by both computers and use two different systems (computers) with separate wallet installations.
+When testing with live WalletConnect (not simulator), you **must** use two different Chia wallet instances. You cannot use the same wallet or installation for both players. The easiest approach is to deploy the gaming system to a URL accessible by both computers and use two different systems with separate wallet installations.
 
 :::
 
 1. Deploy the gaming system to a URL accessible by both computers (does not need to be publicly accessible; local network, VPN, or other private network setup is sufficient)
-2. Use two different computers or systems, each with its own Chia wallet installation
+2. Use two different computers or systems, each with its own Chia wallet installation (2.7.1 or later)
 3. Each player connects their separate wallet via WalletConnect
 4. Follow the standard game flow with both players using their respective wallets
 
 ### Viewing Logs
 
-View Docker container logs for debugging:
+View service logs for debugging:
 
 ```bash
-# View all container logs
-docker ps  # Get container IDs
-docker logs <container-id>
-
-# Follow logs in real-time
-docker logs -f <container-id>
+# Logs appear in the terminal where run-local-demo.sh is running
+# For more control, run services separately (see Building Step by Step)
 ```
-
-### Running Individual Services
-
-For development, you may want to run services separately. See the repository documentation:
-
-- **Lobby Server**: See the [Lobby Server documentation](https://github.com/Chia-Network/chia-gaming/blob/main/resources/nginx/LOBBY.md) for running the lobby service individually
-- **Game Server**: See the [Game Server documentation](https://github.com/Chia-Network/chia-gaming/blob/main/resources/nginx/GAME.md) for running the game service individually
 
 ## Verification
 
 After building and launching the system, verify it's working correctly:
 
-1. **Check Docker Containers**: Ensure both containers are running:
+1. **Check Services**: Ensure all three services are accessible:
 
    ```bash
-   docker ps
+   curl http://localhost:3002  # Player app
+   curl http://localhost:3003  # Tracker
+   curl -X POST http://localhost:5800/get_peak  # Simulator
    ```
 
-   You should see containers for both the lobby server and game server.
-
 2. **Test with Simulator**:
-   - Navigate to `http://localhost:3000` (or your configured port)
+   - Navigate to `http://localhost:3002`
    - Enable simulator mode
    - Create a room and test the connection
 
 3. **Test with Live WalletConnect**:
-   - Connect a Chia wallet via WalletConnect
+   - Connect a Chia wallet (2.7.1 or later) via WalletConnect
    - Verify the connection is established
    - Test creating a room
 
-4. **Check Network Connectivity**: Ensure the backend can reach coinset.org:
-   ```bash
-   # For mainnet
-   curl https://coinset.org
-   # For testnet
-   curl https://testnet11.api.coinset.org
-   ```
+4. **Check WalletConnect (live play only)**: Confirm each test wallet is connected, synced, and approving pending requests in the Chia wallet UI.
 
 ## Deploy to Production
 
-:::warning Config Directory Not Yet Available
+For detailed deployment instructions including asset layout, caching rules, and production configuration, see the [DEPLOYING.md](https://github.com/Chia-Network/chia-gaming/blob/main/DEPLOYING.md) in the chia-gaming repository.
 
-The config directory feature is not yet implemented. This is a [known issue](/guides/gaming-known-issues#easy-developer-configuration-not-available). Currently, you must manually update configuration values in the codebase as described in the [Manual Configuration](#manual-configuration) section.
+Key points:
 
-:::
-
-1. **Manual Configuration**: Update all necessary production-specific configurations manually in the codebase (e.g., live network settings, correct ports, production domain).
-
-2. **Build Images**: Build the production Docker images:
-
-   ```bash
-   ./build-docker-images.sh
-   ```
-
-3. **Launch Images**: Launch the built Docker images on your production server(s).
-
-:::note Distribution
-
-Each image (lobby server and game code server) can be launched on separate physical or virtual servers. Once the config directory feature is available, you'll be able to update the relevant server address parameters through configuration files.
-
-:::
+- The player app and tracker must be served from **different origins** (the lobby loads inside an iframe)
+- WASM files and `.hex` chialisp files must be under the same `basePath` as `index.js`
+- No simulator in production — players connect their Chia wallet via WalletConnect
+- Use `tools/build-deploy.sh` to produce deployment zip archives (see [DEPLOYING.md](https://github.com/Chia-Network/chia-gaming/blob/main/DEPLOYING.md))
 
 ## Manual Configuration
 
-:::warning Manual Configuration Required
+### Network (mainnet only)
 
-The easy developer configuration is still in development. Currently, developers must manually update various parameters in the codebase before building and deploying.
+**Alpha 2 supports mainnet only.** The player app is wired for mainnet in source:
 
-:::
+- `front-end/src/constants/env.ts` — `CHAIN_ID = 'chia:mainnet'`
+- `src/common/constants.rs` — `AGG_SIG_ME_ADDITIONAL_DATA` is the mainnet value
 
-### Network Updates
-
-To configure the network settings (e.g., switching to testnet), update the following files:
-
-1. **agg_sig_additional change to testnet constant**:
-   - File: `src/common/constants.rs`
-   - Location: Line 32
-   - Update the `AGG_SIG_ME_ADDITIONAL_DATA` constant to the testnet value. Replace the mainnet array with:
-     ```rust
-     pub const AGG_SIG_ME_ADDITIONAL_DATA: [u8; 32] = [
-         0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
-         0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
-     ];
-     ```
-   - [View in repository](https://github.com/Chia-Network/chia-gaming/blob/e716262cdf907e007af26c137a90f50d25ffa344/src/common/constants.rs#L32)
-
-2. **chain_id to testnet**:
-   - File: `resources/gaming-fe/src/constants/env.ts`
-   - Location: Line 3
-   - Update the `chain_id` to testnet: `chia:testnet`
-   - [View in repository](https://github.com/Chia-Network/chia-gaming/blob/e716262cdf907e007af26c137a90f50d25ffa344/resources/gaming-fe/src/constants/env.ts#L3)
-
-3. **coinset URL for testnet**:
-   - Update **all instances** of `coinset.org` to the testnet endpoint: `https://testnet11.api.coinset.org`
-   - This includes (but is not limited to):
-     - File: `resources/nginx/game.conf` (Content Security Policy header, line 17)
-     - File: `resources/lobby-service/src/index.ts` (Content Security Policy header, line 48)
-     - Any other files that reference `coinset.org`
-   - [View examples in repository](https://github.com/Chia-Network/chia-gaming/blob/e716262cdf907e007af26c137a90f50d25ffa344/resources/nginx/game.conf#L17)
+There is no supported testnet configuration for Alpha 2. Use the **simulator** (`run-local-demo.sh`) for development without mainnet XCH. Do not change these constants for testnet unless you are doing unsupported custom experimentation.
 
 ### WalletConnect Project Info Updates
 
 To configure WalletConnect settings, you'll need to obtain a WalletConnect Project ID. For registration and troubleshooting, refer to the [WalletConnect documentation](https://walletconnect.com) and your WalletConnect account dashboard.
 
-Once you have your Project ID, update the following:
+The repository ships a default WalletConnect **Project ID** in `front-end/src/constants/env.ts` for development. **Production or partner deployments should register their own project** at [WalletConnect Cloud](https://cloud.walletconnect.com) and replace that value before building the player app.
 
-1. **Project ID**:
-   - File: `resources/gaming-fe/src/constants/env.ts`
-   - Location: Line 1
-   - Update the WalletConnect project ID with your registered Project ID
-   - [View in repository](https://github.com/Chia-Network/chia-gaming/blob/e716262cdf907e007af26c137a90f50d25ffa344/resources/gaming-fe/src/constants/env.ts#L1)
+Once you have your Project ID, update:
 
-2. **Project Info**:
-   - File: `resources/gaming-fe/src/constants/wallet-connect.ts`
-   - Location: Line 52
-   - Update the WalletConnect project information with your project details
-   - [View in repository](https://github.com/Chia-Network/chia-gaming/blob/e716262cdf907e007af26c137a90f50d25ffa344/resources/gaming-fe/src/constants/wallet-connect.ts#L52)
+1. **Project ID**: `front-end/src/constants/env.ts` — update `PROJECT_ID` (and `RELAY_URL` if needed)
+2. **Chain and methods**: `front-end/src/constants/wallet-connect.ts` — update `REQUIRED_NAMESPACES` / `ChiaMethod` if the wallet API changes (must match what the player app calls in `RealBlockchainInterface.ts`)
 
-### Ports and Domain Updates
+### Port Configuration
 
-**Default Ports:**
+Default ports for `run-local-demo.sh`:
 
-The default Docker configuration exposes the following ports:
+- **Port 3002**: Player app (frontend web interface)
+- **Port 3003**: Tracker (lobby + relay service)
+- **Port 5800**: Simulator (HTTP)
+- **Port 5801**: Simulator (WebSocket)
 
-- **Port 3000**: Frontend web interface (game UI)
-- **Port 3001**: Lobby server API
-- **Port 5800**: Simulator service
+Override with environment variables:
 
-:::note Port Configuration
+```bash
+GAME_PORT=4000 TRACKER_PORT=4001 ./run-local-demo.sh
+```
 
-Ports are manually coded in the Docker build and run commands within `build-docker-images.sh` and `run-docker-demo.sh`. To change ports, edit these scripts directly.
-
-:::
-
-For production deployments, ports and domain should be configured via the methods documented in the repository:
-
-- **Game Server**: See the [Game Server documentation](https://github.com/Chia-Network/chia-gaming/blob/main/resources/nginx/GAME.md#using-the-archive-and-script) for configuring ports and domain
-- **Lobby Server**: See the [Lobby Server documentation](https://github.com/Chia-Network/chia-gaming/blob/main/resources/nginx/LOBBY.md#using-the-archive-and-script) for configuring ports and domain
+For production deployments, see the [DEPLOYING.md](https://github.com/Chia-Network/chia-gaming/blob/main/DEPLOYING.md) in the repository for port and domain configuration.

--- a/docs/guides/chia-gaming/gaming-known-issues.md
+++ b/docs/guides/chia-gaming/gaming-known-issues.md
@@ -78,9 +78,9 @@ The config-directory workflow described in older material is not available. Netw
 
 ### Handshake Timing
 
-**Problem**: Opening a channel requires one on-chain spend bundle to confirm; both wallets must see the channel reach **Active**, which takes several minutes on mainnet (~1 minute per peak).
+**Problem**: Opening a channel requires one on-chain spend bundle to confirm; both wallets must see the channel reach **Active**, which takes several minutes on mainnet (~1 minute per peak). During the handshake, each wallet must also approve **several** WalletConnect requests (`chia_selectCoins`, `chia_createOfferForIds`, and `chia_pushTransactions`), not a single tap.
 
-**Impact**: Player 2 may wait a long time before the lobby appears. This is expected for on-chain handshakes.
+**Impact**: Player 2 may wait a long time before the lobby appears. This is expected for on-chain handshakes. If progress stalls, check both wallets for pending approvals.
 
 ### Pending WalletConnect Requests
 

--- a/docs/guides/chia-gaming/gaming-known-issues.md
+++ b/docs/guides/chia-gaming/gaming-known-issues.md
@@ -3,49 +3,93 @@ slug: /guides/gaming-known-issues
 title: Known Issues
 ---
 
-This document lists known issues for the Chia Gaming system, organized by developer and user-facing concerns.
+:::warning Alpha Release
 
-:::tip Troubleshooting
-
-If you're experiencing issues not listed here, or need help resolving these known issues, see the [Troubleshooting Guide](/guides/gaming-troubleshooting) for detailed solutions and workarounds.
+This is an **alpha release**. Expect issues and breaking changes. The following known issues are being tracked and worked on.
 
 :::
 
+:::tip Troubleshooting
+
+For steps to resolve common problems, see the [Troubleshooting Guide](/guides/gaming-troubleshooting).
+
+:::
+
+<!-- Legacy anchors preserved for external links -->
+
+<span id="developer-issues"></span>
+<span id="common-setup-issues"></span>
+<span id="easy-developer-configuration-not-available"></span>
+<span id="user-facing-issues"></span>
+<span id="uiux-issues"></span>
+<span id="gameplay-issues"></span>
+<span id="performance-issues"></span>
+
+## Game Availability
+
+**California Poker (CalPoker)** and **Space Poker** are available in Alpha 2 as early releases. On-chain Chialisp, rules, and UI for both games are still undergoing changes.
+
+**Krunk** is coming soon.
+
 ## Developer Issues
-
-### Common Setup Issues
-
-| Issue              | Solution                                                                                                                                                                                                                 |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Old Docker Version | Install Docker via Snap instead of apt to ensure you get the latest stable version.                                                                                                                                      |
-| Docker Permissions | Docker often installs with root privileges. To allow your user to run Docker commands without sudo:<br/>1. Run: `sudo usermod -aG docker $USER`<br/>2. Run: `newgrp docker`<br/>3. Reattempt the image build or command. |
 
 ### Easy Developer Configuration Not Available
 
-The easy developer configuration is still in development. Currently, developers must manually update various parameters in the codebase before building and deploying.
+The config-directory workflow described in older material is not available. Network, WalletConnect, and port settings are updated in the codebase. See the [Manual Configuration](/guides/gaming-developers-guide#manual-configuration) section in the Developers Guide.
 
-**Workaround**: See the [Manual Configuration section](/guides/gaming-developers-guide#manual-configuration) in the Developers Guide for detailed instructions on how to manually configure network settings, WalletConnect project info, ports, and domain.
+### WASM Build Failures on macOS
+
+**Problem**: WASM builds may fail with clang-related errors on macOS.
+
+**Workaround**: Install Homebrew LLVM (`brew install llvm`). Build scripts detect Homebrew LLVM paths automatically. See the [Developers Guide](/guides/gaming-developers-guide) prerequisites.
+
+### `ERR_PNPM_IGNORED_BUILDS` Warning
+
+**Problem**: During `pnpm install` you may see warnings about ignored build scripts for `@parcel/watcher` and `esbuild`.
+
+**Impact**: This is harmless. Those packages ship pre-built native binaries as fallbacks, so the build completes without running those scripts.
+
+**Resolution**: Run `pnpm approve-builds` once in `front-end/` or `lobby/` and commit the updated `.pnpm-approve-builds` file to silence the warning. The lobby build in `tools/build-deploy.sh` also uses `pnpm install --ignore-scripts` in `lobby/` for the same reason.
 
 ## User-Facing Issues
 
-### UI/UX Issues
+### "Generate Room" button contrast (fixed in Alpha 2)
 
-- **"Generate Room" button is light-gray on medium-gray**: The button may be difficult to see due to low contrast between the button color and background.
+**Status:** **Fixed in Alpha 2.** Earlier builds used low-contrast styling for the Generate Room control.
 
-- **UX has limited information regarding what is happening during handshake**: The interface will be improved to provide better feedback about the current state of operations, particularly during handshaking and connection processes.
+### Handshake progress feedback (fixed in Alpha 2)
 
-### Gameplay Issues
+**Status:** **Fixed in Alpha 2.** The UI now shows clearer progress during the handshake and channel-confirmation phases.
 
-- **Funds left on-chain after shutdown**: When using a live WalletConnect instance, funds will be left on-chain after shutdown. Upon shutdown, a new game is created, leading to one game's worth of funds being left on-chain and not returned to users. For example, if the game stake is 10 mojo, then 10 mojos will remain on-chain after shutting down the session (once per lobby not per game). **Use the simulator for development to avoid this issue. This is a high priority issue which we are working to fix ASAP.**
+### Funds left on-chain after shutdown (fixed in Alpha 2)
 
-- **When you leave the game, both sides have to keep browser open until shutdown completes**: Both players must keep their browsers open until the shutdown process completes. Closing the browser prematurely may cause issues.
+**Status:** **Fixed in Alpha 2.** Older alpha builds could leave one game stake on-chain after ending a live WalletConnect session. Current Alpha 2 builds return channel funds on shutdown. If you still see stranded coins, confirm you are on an Alpha 2 build and not an older artifact.
 
-- **Chia Wallet does not raise to the foreground when a WalletConnect auth dialog appears**: The chia reference wallet will be updated to automatically come to the foreground when authentication is required, but this does not currently occur. Users need to manually bring the wallet application to the foreground.
+- **Keep browsers open until shutdown completes**: Both players should keep the browser open until cooperative shutdown finishes. Closing early can interrupt the shutdown flow.
+- **Chia Wallet does not come to the foreground for WalletConnect**: When the wallet needs approval, you may need to switch to the wallet app manually.
 
-- **Save and load/reload is not functional**: Game sessions are not persisted. If a user refreshes their browser or clears browser storage (localStorage, cache, etc.), the game session will be lost and a new session will need to be created. **This can lead to lost funds if a session is interrupted during gameplay.**
+### Session Persistence
 
-### Performance Issues
+**Problem**: Game sessions are stored in browser localStorage. Refreshing the page or clearing browser data loses the session.
 
-- **Handshaking on-chain takes a long time**: Before the game starts, 3 nodes (player wallet nodes and coinset.org) have to observe 2 on-chain transactions (in order). The lobby will take a long time to appear for Bob (Player 2). This is expected behavior due to blockchain confirmation requirements, but the wait time can be significant.
+**Impact**: If a session is lost mid-game, channel coins remain on-chain until timeout. Funds are not necessarily lost permanently, but coins may be locked until the timeout expires.
 
-- **Game server and lobby server interaction**: The current implementation of how the game server and lobby server interact may have performance limitations. This connection may be refactored in future versions to improve performance and scalability.
+**Workaround**: Do not refresh or clear browser data during active games.
+
+### Handshake Timing
+
+**Problem**: Opening a channel requires one on-chain spend bundle to confirm; both wallets must see the channel reach **Active**, which takes several minutes on mainnet (~1 minute per peak).
+
+**Impact**: Player 2 may wait a long time before the lobby appears. This is expected for on-chain handshakes.
+
+### Pending WalletConnect Requests
+
+**Problem**: The Chia wallet may have pending WalletConnect requests that are not immediately visible, so the handshake or gameplay can appear stuck.
+
+**Workaround**: Check the Chia wallet application for pending approval requests.
+
+### Tracker WebSocket Relay
+
+**Problem**: Game messages are relayed through the tracker WebSocket. If that connection drops for an extended time, play stalls.
+
+**Impact**: Brief outages may recover via tracker auto-reconnect; a lost peer pairing may require re-matching on the tracker (see `CONNECTIVITY.md` in the chia-gaming repository).

--- a/docs/guides/chia-gaming/gaming-krunk-rules.md
+++ b/docs/guides/chia-gaming/gaming-krunk-rules.md
@@ -50,7 +50,7 @@ In this example:
 
 - First guess "RATES" had one letter (S) in the word but wrong position
 - Second guess "SPOIL" had two letters (S and L) in wrong positions
-- Third guess "MOUSY" had three letters correct (O, U, Y) with two in right positions
+- Third guess "MOUSY" had three letters correct (O, U, Y) in right positions
 - Fourth guess "BOSSY" was correct
 
 ## Scoring and Rewards

--- a/docs/guides/chia-gaming/gaming-space-poker-rules.md
+++ b/docs/guides/chia-gaming/gaming-space-poker-rules.md
@@ -3,23 +3,41 @@ slug: /guides/gaming-space-poker-rules
 title: Space Poker Rules
 ---
 
-:::warning Coming Soon
+:::warning Early Alpha Release
 
-Space Poker will be available in a future release. The rules below are based on current known game mechanics and may be subject to change.
+Space Poker is included in Alpha 2 as an early release. On-chain Chialisp, rules, and UI may change before general availability. The rules below match the current implementation in the [chia-gaming](https://github.com/Chia-Network/chia-gaming) repository (`clsp/games/spacepoker/`).
 
 :::
 
 ## Objective
 
-Space Poker is a poker variant played with two simultaneous games. Players receive two hole cards with a boost bit (+ or -) that affects hand rankings. The goal is to win both games or maximize winnings across both games.
+Space Poker is a **two-player, suitless Hold'em-style** game on a **single shared board**. Each player gets two hole cards; five community cards are dealt (flop, turn, river). Players bet over four streets, then the best five-card hand wins the pot. Each player also has a **boost** flag (+ or −) that can break ties within the same hand class.
+
+There is **one hand per game** in the channel—not two parallel boards.
 
 ## Setup
 
-- Each player receives two hole cards selected at random from 2-A (T=10, J=11, Q=12, K=13, A=14)
-- Each hole card has a boost bit which is + or - with a ⅓ chance of being +
-- Both players ante a minraise at the start of each hand
-- All raise amounts are multiples of the minraise
-- Two games proceed simultaneously until both are complete
+### Stakes
+
+When starting Space Poker in the player app, you set:
+
+- **Unit size** — mojos per betting unit (`bet_unit` on-chain).
+- **Stack size** — number of units each player brings (default **10** in the UI).
+
+Total locked stake for the hand is `2 × unit size × stack size` mojos (`AMOUNT` in the on-chain validators). The minimum increment used in the protocol is **`bet_unit = total per-player stake ÷ 10`**. The UI slider raises in whole units; the chain accepts any valid non-negative raise in mojos up to each player's remaining stack.
+
+### Cards and boost
+
+- Hole cards and community cards are ranks **2–A** only (T=10, J=11, Q=12, K=13, A=14). **There are no suits.**
+- Each player receives **two hole cards**, drawn deterministically from commit entropy (see `derive_all_cards` in chia-gaming).
+- Each player gets **one boost** for the hand: **+** with probability **⅓**, otherwise **−** (derived from hashed commit material, not from individual cards).
+- Community cards are **shared**: flop (3), then turn (1), then river (1), revealed in that order as streets complete.
+
+### Opening the hand
+
+1. Both players post hash-chain commits (`commitA`, `commitB`).
+2. **`commitB` posts the first unit** into the pot (`half_pot` starts at one `bet_unit`).
+3. Betting begins at **pre-flop** (`N = 4` in the validator state).
 
 ## Hand Rankings
 
@@ -30,62 +48,95 @@ From lowest to highest:
 3. **Two Pair**: Two different pairs
 4. **Set (Three of a Kind)**: Three cards of the same rank
 5. **Full House**: Three of a kind plus a pair
-6. **Straight**: Five consecutive cards (no ace-to-five straight)
+6. **Straight**: Five consecutive ranks (high card of the straight breaks ties within the class)
 7. **Four of a Kind**: Four cards of the same rank
 8. **Five of a Kind**: Five cards of the same rank
 
-**Important Differences from Traditional Poker:**
+**Important differences from traditional poker:**
 
-- **No Flushes**: Unlike traditional poker, there are no flushes in Space Poker
-- **Five of a Kind**: This is the highest possible hand
-- **No Ace-to-Five Straight**: The straight A-2-3-4-5 is not valid
+- **No flushes** — ranks only; suits do not exist.
+- **Five of a kind** is the highest hand.
+- **No ace-low wheel** — A-2-3-4-5 is **not** a straight (only five consecutive ranks where the top card is exactly four above the bottom, e.g. 6-7-8-9-10).
+- **Straight beats full house** — in this suitless deck, straights are rarer than full houses (see `space_hand_eval.clinc`).
 
 ## Tiebreakers
 
-1. **Hand Type**: Higher hand type wins
-2. **Boost Bit**: The boost bit is the first tiebreaker after hand type
-3. **Standard Poker Tiebreaks**: After boost bit, standard poker tiebreaking rules apply
+Hands are compared as structured values `(hand counts… boost rank kickers…)` using lexicographic ordering (`deep_compare` in Chialisp):
+
+1. **Hand class** — e.g. full house beats set; straight beats full house.
+2. **Boost** — with the **same** class, **+** beats **−** (boost does **not** upgrade you to a higher class—a boosted set still loses to an unboosted full house).
+3. **Kickers** — remaining rank fields in the hand tuple, highest first.
+
+At showdown each side automatically selects the **best five cards** from their seven (two hole + five board) via `space_hand_calc`; players do not manually pick cards in normal play.
 
 ## Gameplay
 
-### Turn Structure
-
-- Players always alternate turns
-- On your turn, you can either **call** or **raise**
-- At the beginning of a street, calling doesn't end the street
-- After the first action on a street, calling ends the street and causes a reveal of the next set of cards or showdown if it's on the river
-
 ### Streets
 
-The game follows standard poker street structure:
+Four betting rounds map to standard street names:
 
-- **Pre-flop**: After receiving hole cards
-- **Flop**: First three community cards
-- **Turn**: Fourth community card
-- **River**: Fifth and final community card
+| Validator `N` | Street   | Board state                         |
+| ------------- | -------- | ----------------------------------- |
+| 4             | Pre-flop | Hole cards only                     |
+| 3             | Flop     | Three community cards               |
+| 2             | Turn     | Fourth community card               |
+| 1             | River    | Fifth community card; then showdown |
+
+### Pre-flop coin toss
+
+On the first street only (`N = 4`), a **coin toss** (from compared hash-chain images) decides who **opens** betting:
+
+- **Opener** — sends an **open** move: optional raise amount (0 = **check**).
+- **Non-opener** — may **pong** (defer opening; roles swap, toss flips) once, then the other player opens.
+
+This is enforced on-chain in `begin_round.clsp` so the opener cannot ignore an unfavorable toss by checking.
+
+### Turn Structure
+
+Players **alternate** on each street. The **opener** acts first with **check** or **raise**; the other player responds with **call** or **raise** in `mid_round`. A **call** ends the street (or goes to showdown on the river). See **Pre-flop coin toss** above when `N = 4`.
+
+### Actions per street
+
+| Phase         | Your turn options (UI) | On-chain meaning                              |
+| ------------- | ---------------------- | --------------------------------------------- |
+| `begin_round` | **Check** or **Raise** | Open with 0 or more mojos added to `half_pot` |
+| `mid_round`   | **Call** or **Raise**  | Match the current raise, or raise again       |
+| `end`         | (automatic reveal)     | Best-five selection and payout                |
+
+- **Check** — only when you are the opener on a street (`begin_round`).
+- **Call** — matches the last raise and ends the street (or proceeds to showdown on the river).
+- **Raise** — increases the wager; opponent must call or re-raise in `mid_round`.
+- **Fold** (UI only) — ends the hand in the client via **timeout** (`acceptTimeout`); this is **not** a separate validated poker fold opcode. Use only when you intend to forfeit the hand outside normal call/raise flow.
+
+After a call on streets 4–2, the next street deals the next community card(s). After a call on the river (`N = 1`), play moves to **showdown**.
 
 ### Showdown
 
-- The player who made the final call reveals their hole cards first
-- If the other player loses, they don't show their hole cards
-- Winner is determined by hand rankings with boost bit tiebreaker
+- Both players' best five-card hands are computed from seven cards (hole + board).
+- The mover reveals with a preimage and five-card **bitfield**; the waiter must match with their own best five (`end.clsp`).
+- The UI shows win/loss/split, pot result, evaluated hand names, and hole cards when the protocol exposes them in readables (`"call"` on the river or `"end"`).
+- There is no “must show only if you lose” rule in the validators—display follows what the handlers emit.
 
 ### All-In
 
-If a player goes all-in:
-
-- Wait for results to be collated
-- This may be skipped if off-chain and happens fast enough
+Stack limits are enforced by validator state: total committed chips per player cannot exceed half of `AMOUNT`. When a player cannot raise further, they call or check with what remains; there is no separate “all-in” opcode—the UI tracks **stack** and **pot** from `half_pot` and raise amounts.
 
 ## Game Flow
 
-1. **Two Simultaneous Games**: Play proceeds on two games simultaneously until both are done
-2. **Player Actions**: On your turn, raise/call/fold. Hand history and current pot size are shown
-3. **Wait for Opponent**: Wait for opponent to raise/call/fold
-4. **All-In**: If applicable, wait for results to be collated
-5. **Results**: Shows win/loss/split, amount won (if not a split), your hand if it got that far, and opponent's hole cards and hand if known
-6. **Both Results Shown**: After both games complete, options to start new hands or end the session
-7. **End Session**: Session may end due to:
-   - Playing on-chain
-   - Insufficient balance (yours or opponent's)
-   - You or opponent declined to continue
+1. **Proposal** — Agree on unit size and stack size; both fund the game coin.
+2. **Commits** — Hash-chain commits; hole cards and boost are fixed from entropy.
+3. **Pre-flop** — Coin toss (if needed), then check/raise and call/raise until the street closes.
+4. **Flop → Turn → River** — Each street: opener check/raises, opponent calls or raises, then the next board cards appear.
+5. **Showdown** — River call or final reveal; pot split by hand comparison.
+6. **Next hand or session end** — Start another hand from the lobby if balances allow, or shut down the channel (clean shutdown returns funds in Alpha 2 builds).
+
+## Session end
+
+A session may end because:
+
+- Players finish and choose not to continue
+- Insufficient balance for the next stake
+- Clean shutdown or channel close on-chain
+- A player uses **Fold** / timeout in the UI to abandon the current hand
+
+For installation, WalletConnect, and testing steps, see the [Users Guide](/guides/gaming-users-guide) and [Developers Guide](/guides/gaming-developers-guide).

--- a/docs/guides/chia-gaming/gaming-space-poker-rules.md
+++ b/docs/guides/chia-gaming/gaming-space-poker-rules.md
@@ -13,7 +13,7 @@ Space Poker is included in Alpha 2 as an early release. On-chain Chialisp, rules
 
 Space Poker is a **two-player, suitless Hold'em-style** game on a **single shared board**. Each player gets two hole cards; five community cards are dealt (flop, turn, river). Players bet over four streets, then the best five-card hand wins the pot. Each player also has a **boost** flag (+ or −) that can break ties within the same hand class.
 
-There is **one hand per game** in the channel—not two parallel boards.
+There is **one hand per game** in the channel, not two parallel boards.
 
 ## Setup
 
@@ -21,8 +21,8 @@ There is **one hand per game** in the channel—not two parallel boards.
 
 When starting Space Poker in the player app, you set:
 
-- **Unit size** — mojos per betting unit (`bet_unit` on-chain).
-- **Stack size** — number of units each player brings (default **10** in the UI).
+- **Unit size**: mojos per betting unit (`bet_unit` on-chain).
+- **Stack size**: number of units each player brings (default **10** in the UI).
 
 Total locked stake for the hand is `2 × unit size × stack size` mojos (`AMOUNT` in the on-chain validators). The minimum increment used in the protocol is **`bet_unit = total per-player stake ÷ 10`**. The UI slider raises in whole units; the chain accepts any valid non-negative raise in mojos up to each player's remaining stack.
 
@@ -54,18 +54,18 @@ From lowest to highest:
 
 **Important differences from traditional poker:**
 
-- **No flushes** — ranks only; suits do not exist.
+- **No flushes**: ranks only; suits do not exist.
 - **Five of a kind** is the highest hand.
-- **No ace-low wheel** — A-2-3-4-5 is **not** a straight (only five consecutive ranks where the top card is exactly four above the bottom, e.g. 6-7-8-9-10).
-- **Straight beats full house** — in this suitless deck, straights are rarer than full houses (see `space_hand_eval.clinc`).
+- **No ace-low wheel**: A-2-3-4-5 is **not** a straight (only five consecutive ranks where the top card is exactly four above the bottom, e.g. 6-7-8-9-10).
+- **Straight beats full house**: in this suitless deck, straights are rarer than full houses (see `space_hand_eval.clinc`).
 
 ## Tiebreakers
 
 Hands are compared as structured values `(hand counts… boost rank kickers…)` using lexicographic ordering (`deep_compare` in Chialisp):
 
-1. **Hand class** — e.g. full house beats set; straight beats full house.
-2. **Boost** — with the **same** class, **+** beats **−** (boost does **not** upgrade you to a higher class—a boosted set still loses to an unboosted full house).
-3. **Kickers** — remaining rank fields in the hand tuple, highest first.
+1. **Hand class**: e.g. full house beats set; straight beats full house.
+2. **Boost**: with the **same** class, **+** beats **−** (boost does **not** upgrade you to a higher class; a boosted set still loses to an unboosted full house).
+3. **Kickers**: remaining rank fields in the hand tuple, highest first.
 
 At showdown each side automatically selects the **best five cards** from their seven (two hole + five board) via `space_hand_calc`; players do not manually pick cards in normal play.
 
@@ -86,8 +86,8 @@ Four betting rounds map to standard street names:
 
 On the first street only (`N = 4`), a **coin toss** (from compared hash-chain images) decides who **opens** betting:
 
-- **Opener** — sends an **open** move: optional raise amount (0 = **check**).
-- **Non-opener** — may **pong** (defer opening; roles swap, toss flips) once, then the other player opens.
+- **Opener**: sends an **open** move: optional raise amount (0 = **check**).
+- **Non-opener**: may **pong** (defer opening; roles swap, toss flips) once, then the other player opens.
 
 This is enforced on-chain in `begin_round.clsp` so the opener cannot ignore an unfavorable toss by checking.
 
@@ -103,10 +103,10 @@ Players **alternate** on each street. The **opener** acts first with **check** o
 | `mid_round`   | **Call** or **Raise**  | Match the current raise, or raise again       |
 | `end`         | (automatic reveal)     | Best-five selection and payout                |
 
-- **Check** — only when you are the opener on a street (`begin_round`).
-- **Call** — matches the last raise and ends the street (or proceeds to showdown on the river).
-- **Raise** — increases the wager; opponent must call or re-raise in `mid_round`.
-- **Fold** (UI only) — ends the hand in the client via **timeout** (`acceptTimeout`); this is **not** a separate validated poker fold opcode. Use only when you intend to forfeit the hand outside normal call/raise flow.
+- **Check**: only when you are the opener on a street (`begin_round`).
+- **Call**: matches the last raise and ends the street (or proceeds to showdown on the river).
+- **Raise**: increases the wager; opponent must call or re-raise in `mid_round`.
+- **Fold** (UI only): forfeits the current hand through the protocol **timeout** path (`acceptTimeout` in the player app). This is **not** a separate on-chain fold opcode and is **not** a network or connection timeout. Use only when you intend to abandon the hand outside normal call/raise flow.
 
 After a call on streets 4–2, the next street deals the next community card(s). After a call on the river (`N = 1`), play moves to **showdown**.
 
@@ -115,20 +115,20 @@ After a call on streets 4–2, the next street deals the next community card(s).
 - Both players' best five-card hands are computed from seven cards (hole + board).
 - The mover reveals with a preimage and five-card **bitfield**; the waiter must match with their own best five (`end.clsp`).
 - The UI shows win/loss/split, pot result, evaluated hand names, and hole cards when the protocol exposes them in readables (`"call"` on the river or `"end"`).
-- There is no “must show only if you lose” rule in the validators—display follows what the handlers emit.
+- There is no “must show only if you lose” rule in the validators; display follows what the handlers emit.
 
 ### All-In
 
-Stack limits are enforced by validator state: total committed chips per player cannot exceed half of `AMOUNT`. When a player cannot raise further, they call or check with what remains; there is no separate “all-in” opcode—the UI tracks **stack** and **pot** from `half_pot` and raise amounts.
+Stack limits are enforced by validator state: total committed chips per player cannot exceed half of `AMOUNT`. When a player cannot raise further, they call or check with what remains; there is no separate “all-in” opcode; the UI tracks **stack** and **pot** from `half_pot` and raise amounts.
 
 ## Game Flow
 
-1. **Proposal** — Agree on unit size and stack size; both fund the game coin.
-2. **Commits** — Hash-chain commits; hole cards and boost are fixed from entropy.
-3. **Pre-flop** — Coin toss (if needed), then check/raise and call/raise until the street closes.
-4. **Flop → Turn → River** — Each street: opener check/raises, opponent calls or raises, then the next board cards appear.
-5. **Showdown** — River call or final reveal; pot split by hand comparison.
-6. **Next hand or session end** — Start another hand from the lobby if balances allow, or shut down the channel (clean shutdown returns funds in Alpha 2 builds).
+1. **Proposal**: Agree on unit size and stack size; both fund the game coin.
+2. **Commits**: Hash-chain commits; hole cards and boost are fixed from entropy.
+3. **Pre-flop**: Coin toss (if needed), then check/raise and call/raise until the street closes.
+4. **Flop → Turn → River**: Each street: opener check/raises, opponent calls or raises, then the next board cards appear.
+5. **Showdown**: River call or final reveal; pot split by hand comparison.
+6. **Next hand or session end**: Start another hand from the lobby if balances allow, or shut down the channel (clean shutdown returns funds in Alpha 2 builds).
 
 ## Session end
 
@@ -137,6 +137,6 @@ A session may end because:
 - Players finish and choose not to continue
 - Insufficient balance for the next stake
 - Clean shutdown or channel close on-chain
-- A player uses **Fold** / timeout in the UI to abandon the current hand
+- A player uses **Fold** (protocol timeout via `acceptTimeout`) in the UI to abandon the current hand
 
 For installation, WalletConnect, and testing steps, see the [Users Guide](/guides/gaming-users-guide) and [Developers Guide](/guides/gaming-developers-guide).

--- a/docs/guides/chia-gaming/gaming-troubleshooting.md
+++ b/docs/guides/chia-gaming/gaming-troubleshooting.md
@@ -1,255 +1,198 @@
 ---
 slug: /guides/gaming-troubleshooting
-title: Troubleshooting Guide
+title: Troubleshooting
 ---
 
-This troubleshooting guide addresses common issues developers and users may encounter when working with the Chia Gaming system.
+<!-- Legacy anchors preserved for external links -->
+
+<span id="developer-troubleshooting"></span>
+<span id="build-and-deployment-issues"></span>
+<span id="docker-build-fails"></span>
+<span id="containers-wont-start"></span>
+<span id="code-changes-not-reflecting"></span>
+<span id="configuration-issues"></span>
+<span id="walletconnect-connection-fails"></span>
+<span id="network-configuration-issues"></span>
+<span id="port-configuration-issues"></span>
+<span id="development-environment-issues"></span>
+<span id="simulator-not-working"></span>
+<span id="logs-not-appearing"></span>
+<span id="user-troubleshooting"></span>
+<span id="connection-issues"></span>
+<span id="gameplay-issues"></span>
+<span id="session-management-issues"></span>
+<span id="getting-additional-help"></span>
 
 ## Developer Troubleshooting
 
-### Build and Deployment Issues
+## Build Issues
 
-#### Docker Build Fails
+### Rust / WASM
 
-**Symptoms**: The `./build-docker-images.sh` command fails with errors.
+**`wasm-pack` not found or wrong version:**
 
-**Solutions**:
+```bash
+cargo install wasm-pack --version 0.13.1
+```
 
-- **Check Docker Version**: Ensure you have the latest Docker version. Install via Snap instead of apt if needed:
-  ```bash
-  sudo snap install docker
-  ```
-- **Check Docker Permissions**: Ensure your user is in the docker group:
-  ```bash
-  sudo usermod -aG docker $USER
-  newgrp docker
-  ```
-- **Check Disk Space**: Ensure you have sufficient disk space for Docker images:
-  ```bash
-  df -h
-  docker system df
-  ```
-- **Clean Docker Cache**: Try cleaning Docker's build cache:
-  ```bash
-  docker system prune -a
-  ```
-- **Check Logs**: Review the build output for specific error messages.
+**WASM build fails with clang errors (macOS):**
 
-#### Containers Won't Start
+```bash
+brew install llvm
+# Build scripts auto-detect Homebrew LLVM paths
+```
 
-**Symptoms**: Docker containers fail to start or immediately exit.
+**`wasm32-unknown-unknown` target not installed:**
 
-**Solutions**:
+```bash
+rustup target add wasm32-unknown-unknown
+```
 
-- **Check Port Availability**: Ensure ports 3000, 3001, and 5800 are not already in use:
-  ```bash
-  sudo lsof -i :3000
-  sudo lsof -i :3001
-  sudo lsof -i :5800
-  ```
-- **Check Container Logs**: View container logs for error messages:
-  ```bash
-  docker ps -a  # Get container IDs
-  docker logs <container-id>
-  ```
-- **Verify Configuration**: Ensure all manual configuration steps have been completed correctly (see [Manual Configuration](/guides/gaming-developers-guide#manual-configuration)).
+### Node.js / pnpm
 
-#### Code Changes Not Reflecting
+**`pnpm` not found or wrong version:**
 
-**Symptoms**: After making code changes, the changes don't appear when running the application.
+```bash
+corepack enable
+corepack prepare pnpm@10.33.0 --activate
+```
 
-**Solutions**:
+**`ERR_PNPM_IGNORED_BUILDS` warnings:**
 
-- **Rebuild Images**: Code changes require rebuilding Docker images:
-  ```bash
-  ./build-docker-images.sh
-  ```
-- **Check Build Output**: Verify the build completed successfully and your changes were included.
-- **Restart Containers**: Ensure containers were restarted after the build:
-  ```bash
-  docker ps  # Verify containers are running
-  ```
+This is harmless. Silence with:
 
-### Configuration Issues
+```bash
+cd front-end && pnpm approve-builds
+cd lobby && pnpm approve-builds
+```
 
-#### WalletConnect Connection Fails
+**Node version too old:**
 
-**Symptoms**: Unable to connect wallet via WalletConnect.
+The project requires Node.js 20+. Check your version with `node --version`.
 
-**Solutions**:
+### Chialisp / Hex Files
 
-- **Verify Project ID**: Ensure your WalletConnect Project ID is correctly configured in `resources/gaming-fe/src/constants/env.ts`.
-- **Check Network Settings**: Ensure you're using the correct network (testnet vs mainnet) and that the chain_id matches.
-- **WalletConnect Support**: For WalletConnect registration and account issues, refer to the [WalletConnect documentation](https://walletconnect.com) and your WalletConnect account dashboard for troubleshooting.
-- **Review WalletConnect Guide**: See the [WalletConnect Developer Guide](/walletconnect-developer-guide) for detailed setup instructions.
+**Missing `.hex` files:**
 
-#### Network Configuration Issues
+```bash
+find clsp -name '*.hex' -delete
+cp build.rs.disabled build.rs
+cargo build
+```
 
-**Symptoms**: Application can't connect to the blockchain via coinset.org.
+This recompiles all `.clsp` sources to `.hex` via the Rust build script.
 
-**Solutions**:
+## Runtime Issues
 
-- **Verify Network Settings**: Check that `agg_sig_additional` and `chain_id` are set correctly for your target network (testnet or mainnet).
-- **Test Network Connectivity**: Verify the backend can reach coinset.org:
-  ```bash
-  # For mainnet
-  curl https://coinset.org
-  # For testnet
-  curl https://testnet11.api.coinset.org
-  ```
-- **Check Firewall**: Ensure firewall rules allow outbound connections to coinset.org.
-- **Verify Content Security Policy**: Check that CSP headers in `resources/nginx/game.conf` and `resources/lobby-service/src/index.ts` include the correct coinset.org URLs.
+### Simulator
 
-#### Port Configuration Issues
+**Simulator not responding on port 5800:**
 
-**Symptoms**: Can't access the application on expected ports.
+```bash
+# Build and run the simulator
+cargo build --features sim-server --bin chia-gaming-sim
+./target/debug/chia-gaming-sim
+```
 
-**Solutions**:
+The simulator uses hardcoded ports: 5800 (HTTP) and 5801 (WebSocket). Ensure nothing else is using these ports.
 
-- **Check Port Bindings**: Verify Docker port mappings are correct:
-  ```bash
-  docker ps  # Check port mappings
-  ```
-- **Check Default Ports**: Default ports are:
-  - 3000: Frontend web interface
-  - 3001: Lobby server API
-  - 5800: Simulator service
-- **Check Port Availability**: Ensure ports aren't already in use by another application.
-- **Review Port Documentation**: See the [Game Server](https://github.com/Chia-Network/chia-gaming/blob/main/resources/nginx/GAME.md) and [Lobby Server](https://github.com/Chia-Network/chia-gaming/blob/main/resources/nginx/LOBBY.md) documentation for port configuration.
+**Port conflicts with tracker:**
 
-### Development Environment Issues
+The tracker defaults to port 5801 if `PORT` is not set, which conflicts with the simulator WebSocket port. Always set `PORT` explicitly:
 
-#### Simulator Not Working
+From a **source checkout** (local demo):
 
-**Symptoms**: Simulator mode does not function correctly.
+```bash
+PORT=3003 node lobby/lobby-service/dist/index-rollup.cjs --self 'http://localhost:3003' --dir ./lobby/lobby-frontend/serve
+```
 
-**Solutions**:
+From an **Alpha 2 release zip** (`service.js` at the archive root):
 
-- **Verify Simulator Enabled**: Ensure the simulator option is enabled in the UI.
-- **Check Browser Console**: Open browser developer tools and check for JavaScript errors.
-- **Verify Backend Connection**: Ensure the game server is running and accessible.
+```bash
+PORT=3003 node service.js --self 'http://localhost:3003' --dir /path/to/extracted-lobby-archive
+```
 
-#### Logs Not Appearing
+### Player App
 
-**Symptoms**: Can not see application logs for debugging.
+**Blank page or JS errors:**
 
-**Solutions**:
+- Verify WASM files exist in `front-end/dist/` (`chia_gaming_wasm.js`, `chia_gaming_wasm_bg.wasm`)
+- Verify `.hex` files exist in `clsp/` directories
+- Check browser console for 404 errors on assets
 
-- **View Docker Logs**: Use Docker logs to view container output:
-  ```bash
-  docker logs -f <container-id>
-  ```
-- **Check Log Levels**: Verify log levels are set appropriately in the configuration.
-- **Check Container Status**: Ensure containers are running:
-  ```bash
-  docker ps
-  ```
+**`build-meta.json` errors:**
+
+The player app reads `build-meta.json` from the server root to determine the asset base path. If this file is missing or malformed, assets will fail to load. The `run-local-demo.sh` script generates this automatically.
+
+### Tracker
+
+**Tracker iframe not loading:**
+
+- Verify the tracker is running on a **different origin** from the player app
+- Check the browser console for CSP (Content Security Policy) errors
+- Verify the `--self` flag matches the public URL of the tracker
+
+**WebSocket connection failures:**
+
+- Verify the tracker's `--self` URL is accessible from both players' browsers
+- Check for firewall or proxy rules blocking WebSocket upgrades
+- Ensure the tracker process is still running
+
+## WalletConnect Issues
+
+### Connection
+
+**WalletConnect pairing fails:**
+
+- Ensure the Chia wallet is **2.7.1 or later** (minimum)
+- Check that the wallet's WalletConnect feature is enabled
+- Try regenerating the pairing URI by refreshing the player app
+
+**"No matching key" or namespace errors:**
+
+The gaming system requires specific WalletConnect methods. Ensure your wallet supports the `chia` namespace with the required methods. See `front-end/src/constants/wallet-connect.ts` in the repository for the full list.
+
+### During Gameplay
+
+**Handshake hangs:**
+
+1. Check your Chia wallet for pending approval requests
+2. Confirm each wallet is connected, synced, and has no pending WalletConnect approvals
+3. Check the browser console for WebSocket errors
+4. Ensure both players are connected to the same tracker
+
+**Transaction not confirming:**
+
+- Each transaction block takes approximately 1 minute
+- Channel opening uses one on-chain spend bundle; confirmation can take several minutes (about 1 minute per peak)
+- If a transaction is stuck, check the mempool via your wallet
+
+**Wallet disconnects mid-game:**
+
+- Reconnect the wallet via WalletConnect; stalled operations resume when the wallet is back (`CONNECTIVITY.md`)
+- Session data may remain in browser localStorage, but do not refresh the page during an active game
+- If the session is abandoned, channel coins follow on-chain timeout rules (see [Known Issues](/guides/gaming-known-issues))
 
 ## User Troubleshooting
 
 ### Connection Issues
 
-#### WalletConnect Will Not Connect
+**Shutdown hangs or incomplete:**
 
-**Symptoms**: Unable to connect Chia wallet via WalletConnect.
-
-**Solutions**:
-
-- **Check Wallet Version**: Ensure you are using Chia 2.5.7 or later.
-- **Check Wallet Sync**: Verify your wallet is synced with the blockchain.
-- **Clear WalletConnect Cache**: Use the option in the UI to clear the WalletConnect cache, then try connecting again.
-- **Try Reconnecting**: Disconnect and reconnect WalletConnect.
-- **Check Browser**: Try a different browser or clear browser cache.
-- **Verify Network**: Ensure you're on the correct network (testnet vs mainnet) that matches the game server configuration.
-- **WalletConnect Support**: For WalletConnect-specific issues, refer to the [WalletConnect documentation](https://walletconnect.com) and your WalletConnect account dashboard for troubleshooting.
-
-#### Handshake Never Completes
-
-**Symptoms**: Handshake process seems to hang or never completes.
-
-**Solutions**:
-
-- **Check for Pending WalletConnect Requests**: Check your Chia wallet for any pending WalletConnect requests. The wallet may have a request waiting for approval that needs to be confirmed before the handshake can proceed. This is a common cause of handshake delays.
-- **Wait Longer**: Handshaking requires 2 on-chain transactions. Each blockchain peak takes approximately 1 minute, so expect several minutes of waiting.
-- **Check Handshake Status**: Look for on-screen status indicators showing handshake progress.
-- **Verify Wallet Connection**: Ensure both players' wallets are properly connected and synced.
-- **Check Network**: Verify both players have network connectivity and can reach coinset.org.
-- **Try Restarting**: If handshake has been waiting for an unusually long time (10+ minutes), try restarting the connection.
-
-### Gameplay Issues
-
-#### Game Won't Start
-
-**Symptoms**: After handshake completes, game doesn't begin.
-
-**Solutions**:
-
-- **Check Browser Console**: Open browser developer tools (F12) and check for errors.
-- **Verify Both Players Connected**: Ensure both players have successfully connected their wallets.
-- **Check Balance**: Verify both players have sufficient balance for the game stake.
-- **Refresh Page**: Try refreshing the page and reconnecting.
-
-#### Cards or Game Elements Not Displaying
-
-**Symptoms**: Game interface appears but cards or other elements are missing.
-
-**Solutions**:
-
-- **Check Browser Compatibility**: Ensure you're using a modern, supported browser (Chrome, Firefox, Safari, Edge).
-- **Clear Browser Cache**: Clear your browser cache and reload the page.
-- **Check JavaScript**: Ensure JavaScript is enabled in your browser.
-- **Check Console**: Open browser developer tools and check for JavaScript errors.
-
-#### Game Freezes or Becomes Unresponsive
-
-**Symptoms**: Game stops responding to input or freezes.
-
-**Solutions**:
-
-- **Check Network Connection**: Verify you have a stable internet connection.
-- **Refresh Page**: Try refreshing the page (note: this may end the current game session).
-- **Check Browser Console**: Look for error messages in the browser console.
-- **Wait for Opponent**: Some game states require waiting for the opponent's action.
+- Both players should keep the browser open until shutdown completes
+- Check each wallet for pending WalletConnect approvals
 
 ### Session Management Issues
 
-#### Can Not End Session
+**Lost session after refresh:**
 
-**Symptoms**: Unable to end a game session.
+- Sessions are not restored from the server; refreshing clears in-progress UI state
+- Channel coins may remain on-chain until timeout if you abandon mid-game
 
-**Solutions**:
+### Firewall / Proxy
 
-- **Wait for Current Hand**: Complete or forfeit the current hand/game before ending the session.
-- **Check Balance**: If ending due to insufficient balance, ensure the session can be properly closed.
-- **Wait for Opponent**: If opponent is still active, wait for them to complete their turn or end their session.
+**WebSocket connections blocked:**
 
-#### Session Ends Unexpectedly
-
-**Symptoms**: Game session ends without user action.
-
-**Possible Causes**:
-
-- **Insufficient Balance**: One or both players may have insufficient balance to continue.
-- **On-Chain Transaction**: Session may have moved on-chain, requiring session end.
-- **Opponent Ended**: The opponent may have ended the session.
-- **Network Issues**: Network connectivity problems may have caused the session to end.
-
-**Solutions**:
-
-- **Check End Screen**: The end screen will show the reason for ending.
-- **Verify Balance**: Ensure you have sufficient balance for the game stake.
-- **Check Network**: Verify network connectivity is stable.
-
-## Getting Additional Help
-
-If you continue to experience issues after trying these troubleshooting steps:
-
-1. **Check Known Issues**: Review the [Known Issues](/guides/gaming-known-issues) document for documented problems and workarounds.
-
-2. **Review Documentation**:
-   - [Developers Guide](/guides/gaming-developers-guide)
-   - [Users Guide](/guides/gaming-users-guide)
-
-3. **Check Repository**: Review the [chia-gaming repository](https://github.com/Chia-Network/chia-gaming) for additional information and issue reports.
-
-4. **Support**: For additional support, visit the [Gaming channel](https://discord.com/channels/1034523881404370984/1275119503273103381) in the official Chia Discord server.
+- Ensure your network allows WebSocket connections (HTTP Upgrade)
+- If behind a corporate proxy, WebSocket traffic may be blocked
+- The tracker uses standard HTTP ports; configure your proxy to allow WebSocket upgrades on the tracker's port

--- a/docs/guides/chia-gaming/gaming-troubleshooting.md
+++ b/docs/guides/chia-gaming/gaming-troubleshooting.md
@@ -75,12 +75,10 @@ The project requires Node.js 20+. Check your version with `node --version`.
 **Missing `.hex` files:**
 
 ```bash
-find clsp -name '*.hex' -delete
-cp build.rs.disabled build.rs
-cargo build
+./tools/build-chialisp.sh
 ```
 
-This recompiles all `.clsp` sources to `.hex` via the Rust build script.
+This recompiles all `.clsp` sources to `.hex` (same script used by `run-local-demo.sh` and `tools/build-deploy.sh`).
 
 ## Runtime Issues
 
@@ -175,6 +173,8 @@ The gaming system requires specific WalletConnect methods. Ensure your wallet su
 
 ## User Troubleshooting
 
+For documented limitations and workarounds, see [Known Issues](/guides/gaming-known-issues).
+
 ### Connection Issues
 
 **Shutdown hangs or incomplete:**
@@ -196,3 +196,18 @@ The gaming system requires specific WalletConnect methods. Ensure your wallet su
 - Ensure your network allows WebSocket connections (HTTP Upgrade)
 - If behind a corporate proxy, WebSocket traffic may be blocked
 - The tracker uses standard HTTP ports; configure your proxy to allow WebSocket upgrades on the tracker's port
+
+## Getting Additional Help
+
+If you continue to experience issues after trying these troubleshooting steps:
+
+1. **Check Known Issues**: Review the [Known Issues](/guides/gaming-known-issues) document for documented problems and workarounds.
+
+2. **Review Documentation**:
+   - [Developers Guide](/guides/gaming-developers-guide)
+   - [Users Guide](/guides/gaming-users-guide)
+   - [Architecture](/guides/gaming-architecture)
+
+3. **Check Repository**: Review the [chia-gaming repository](https://github.com/Chia-Network/chia-gaming) for additional information and issue reports.
+
+4. **Support**: For additional support, visit the [Gaming channel](https://discord.com/channels/1034523881404370984/1275119503273103381) in the official Chia Discord server.

--- a/docs/guides/chia-gaming/gaming-users-guide.md
+++ b/docs/guides/chia-gaming/gaming-users-guide.md
@@ -11,53 +11,41 @@ This user guide is intended to help developers test their gaming implementations
 
 :::warning Session Persistence
 
-**Game sessions are not saved.** If you refresh your browser or clear browser storage (localStorage, cache, etc.), your game session will be lost and you will need to create a new session. **This can result in lost funds if a session is interrupted during gameplay.** Do not refresh your browser or clear browser data while a game is in progress.
+**Game sessions are not saved.** If you refresh your browser or clear browser storage (localStorage, cache, etc.), your game session will be lost and you will need to create a new session. Do not refresh your browser or clear browser data while a game is in progress.
 
 :::
 
-:::danger Funds Left On-Chain
+:::note Funds on shutdown (Alpha 2)
 
-**When using a live WalletConnect instance, funds will be left on-chain after shutdown.** Upon shutdown, a new game is created, leading to one game's worth of funds being left on-chain and not returned to users. For example, if the game stake is 10 mojo, then 10 mojos will remain on-chain after shutting down the session (once per lobby not per game). **Use the simulator for development to avoid this issue. This is a high priority issue which we are working to fix ASAP.**
+**Fixed in Alpha 2:** Earlier alpha builds could leave one stake worth of funds on-chain after a live WalletConnect session shut down. Alpha 2 returns channel funds on shutdown. If you test an older build, use the simulator for development until you are on Alpha 2.
 
 :::
 
 ## Intro
 
-This guide walks through testing a Chia Gaming implementation with two players (Alice and Bob). The system uses coinset.org for blockchain data and WalletConnect for wallet transactions. Both services are required for gameplay.
+This guide walks through testing a Chia Gaming implementation with two players (Alice and Bob). For live testing, each player connects a Chia wallet (**2.7.1 or later**; required minimum for Alpha 2) via WalletConnect. The player app reads chain state and submits transactions through the wallet connection (see `front-end/src/hooks/RealBlockchainInterface.ts` in the chia-gaming repository). A tracker service relays lobby and game messages between the two browsers.
+
+:::important Two players, two wallets
+
+Live WalletConnect testing requires **two separate wallet installations** (for example two computers, or two user profiles each with its own wallet). You cannot run both players from the same wallet on one machine. See the [Developers Guide](/guides/gaming-developers-guide) testing section for details.
+
+:::
 
 :::note Handshaking Timing
 
-Each transaction block takes approximately 1 minute. The handshake requires 2 on-chain transactions to be observed, so expect several minutes of waiting time. The handshake status will be displayed on-screen, and completion results in the screen changing to the game screen.
+Each peak (block) on mainnet takes approximately 1 minute. Opening a channel uses **one** on-chain spend bundle (both players co-sign the combined funding transaction during the A–F handshake; see `OVERVIEW.md` in the chia-gaming repository). Each wallet must see that transaction confirm and the channel reach **Active** before play begins, so expect several minutes of waiting. The UI shows handshake progress during this period.
 
 :::
 
 ## Player 1: Alice
 
-1. **Visit the game server**: Navigate to the game server URL.
+1. **Visit the player app**: Navigate to the player app URL (e.g. `http://localhost:3002` for local development).
 
-   <!-- ![WalletConnect Screen](/img/gaming/calpoker-walletConnect.png) -->
-
-   _[Image placeholder: walletConnect Screen - calpoker-lobby.png]_
-
-   _Screenshot from alpha - UI may change_
-
-2. **Connect with WalletConnect**: Use WalletConnect to connect your Chia wallet to the game. For live WalletConnect testing, do not select "Simulator".
-
-   :::danger Funds Left On-Chain
-
-   **When using a live WalletConnect instance, funds will be left on-chain after shutdown.** Upon shutdown, a new game is created, leading to one game's worth of funds being left on-chain and not returned to users. For example, if the game stake is 10 mojo, then 10 mojos will remain on-chain after shutting down the session (once per lobby not per game). **Use the simulator for development to avoid this issue.**
-
-   :::
+2. **Connect with WalletConnect**: Use WalletConnect to connect a Chia wallet (2.7.1 or later) to the game. For live WalletConnect testing, do not select "Simulator".
 
 3. **Check Your Light Wallet**: You should see a "getWalletBalance" request in your Chia Light Wallet. Choose "remember this decision" and confirm the request.
 
 4. **Start a New Room**: Create a new game room and copy the invitation URL.
-
-   <!-- ![Lobby Screen](/img/gaming/calpoker-lobby.png) -->
-
-   _[Image placeholder: Lobby Screen - calpoker-lobby.png]_
-
-   _Screenshot from alpha - UI may change_
 
 5. **Send the Invitation URL to Bob**: Share the room invitation URL with the second player (Bob).
 
@@ -65,19 +53,15 @@ Each transaction block takes approximately 1 minute. The handshake requires 2 on
 
 1. **Paste URL**: Paste the invitation URL into a browser that does not share session state with Alice (e.g., another computer, or an incognito/private window).
 
-2. **Wait for Handshake**: Wait until the handshake is complete. The handshake status will be displayed on-screen.
+2. **Connect Wallet**: Connect your separate Chia wallet (2.7.1 or later) via WalletConnect.
 
-   <!-- ![Handshake in Progress](/img/gaming/calpoker-handshake.png) -->
-
-   _[Image placeholder: Handshake in Progress - calpoker-handshake.png]_
-
-   _Screenshot from alpha - UI may change_
+3. **Wait for Handshake**: Wait until the handshake is complete. The handshake status will be displayed on-screen.
 
    Once complete, the screen will automatically change to the game lobby screen.
 
 :::warning Handshaking Time
 
-Handshaking on-chain takes a long time. Before the game starts, 3 nodes (player wallet nodes and coinset.org) have to observe 2 on-chain transactions (in order). Each blockchain peak takes approximately 1 minute, so expect several minutes of waiting time. The lobby may take a several minutes to appear for Bob.
+Handshaking on-chain takes a long time. Before the game starts, the channel-creation transaction must confirm and both wallets must see the channel become **Active**. Each peak takes approximately 1 minute, so expect several minutes of waiting. The lobby may take several minutes to appear for Bob.
 
 :::
 
@@ -89,15 +73,9 @@ If the handshake seems to hang, check your Chia wallet for any pending WalletCon
 
 ## Gameplay
 
-Once both players are connected and the handshake is complete, you can begin playing. The current release includes **[California Poker](/guides/gaming-california-poker-rules)**, with **[Space Poker](/guides/gaming-space-poker-rules)** and **[Krunk](/guides/gaming-krunk-rules)** coming in future releases.
+Once both players are connected and the handshake is complete, choose a game in the lobby. Alpha 2 includes **[California Poker](/guides/gaming-california-poker-rules)** (CalPoker) and **[Space Poker](/guides/gaming-space-poker-rules)** as early releases—on-chain Chialisp, rules, and UI for both may still change. **[Krunk](/guides/gaming-krunk-rules)** is coming soon.
 
 ## Game Completion
-
-<!-- ![Game Completion](/img/gaming/calpoker-completion.png) -->
-
-_[Image placeholder: Game Completion - calpoker-completion.png]_
-
-_Screenshot from alpha - UI may change_
 
 After a game completes, you'll see the results screen with options to start a new hand or end the session.
 

--- a/docs/guides/chia-gaming/gaming-users-guide.md
+++ b/docs/guides/chia-gaming/gaming-users-guide.md
@@ -25,6 +25,12 @@ This user guide is intended to help developers test their gaming implementations
 
 This guide walks through testing a Chia Gaming implementation with two players (Alice and Bob). For live testing, each player connects a Chia wallet (**2.7.1 or later**; required minimum for Alpha 2) via WalletConnect. The player app reads chain state and submits transactions through the wallet connection (see `front-end/src/hooks/RealBlockchainInterface.ts` in the chia-gaming repository). A tracker service relays lobby and game messages between the two browsers.
 
+:::warning Mainnet only (Alpha 2)
+
+Live WalletConnect play requires a **mainnet** Chia wallet. Alpha 2 does not support testnet. Use **Simulator** mode in the player app for development without mainnet XCH.
+
+:::
+
 :::important Two players, two wallets
 
 Live WalletConnect testing requires **two separate wallet installations** (for example two computers, or two user profiles each with its own wallet). You cannot run both players from the same wallet on one machine. See the [Developers Guide](/guides/gaming-developers-guide) testing section for details.
@@ -33,7 +39,7 @@ Live WalletConnect testing requires **two separate wallet installations** (for e
 
 :::note Handshaking Timing
 
-Each peak (block) on mainnet takes approximately 1 minute. Opening a channel uses **one** on-chain spend bundle (both players co-sign the combined funding transaction during the A–F handshake; see `OVERVIEW.md` in the chia-gaming repository). Each wallet must see that transaction confirm and the channel reach **Active** before play begins, so expect several minutes of waiting. The UI shows handshake progress during this period.
+Each peak (block) on mainnet takes approximately 1 minute. Opening a channel uses **one** on-chain spend bundle (both players co-sign the combined funding transaction during the A–F handshake; see `OVERVIEW.md` in the chia-gaming repository). Each wallet must still approve **several** WalletConnect requests during the handshake (coin selection, funding offers, and pushing the transaction), not just one prompt. Each wallet must see that transaction confirm and the channel reach **Active** before play begins, so expect several minutes of waiting. The UI shows handshake progress during this period.
 
 :::
 
@@ -73,7 +79,7 @@ If the handshake seems to hang, check your Chia wallet for any pending WalletCon
 
 ## Gameplay
 
-Once both players are connected and the handshake is complete, choose a game in the lobby. Alpha 2 includes **[California Poker](/guides/gaming-california-poker-rules)** (CalPoker) and **[Space Poker](/guides/gaming-space-poker-rules)** as early releases—on-chain Chialisp, rules, and UI for both may still change. **[Krunk](/guides/gaming-krunk-rules)** is coming soon.
+Once both players are connected and the handshake is complete, choose a game in the lobby. Alpha 2 includes **[California Poker](/guides/gaming-california-poker-rules)** (CalPoker) and **[Space Poker](/guides/gaming-space-poker-rules)** as early releases; on-chain Chialisp, rules, and UI for both may still change. **[Krunk](/guides/gaming-krunk-rules)** is coming soon.
 
 ## Game Completion
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -482,6 +482,7 @@ module.exports = {
           items: [
             'guides/chia-gaming/gaming-developers-guide',
             'guides/chia-gaming/gaming-users-guide',
+            'guides/chia-gaming/gaming-architecture',
             {
               type: 'category',
               label: 'Game Rules',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact; risk is limited to possible doc inaccuracies for readers.
> 
> **Overview**
> This PR refreshes the **Chia Gaming** docs for **Alpha 2**: new architecture guide, sidebar entry, and broad edits across developer, user, rules, known-issues, and troubleshooting pages.
> 
> The **Developers Guide** drops the Docker-first flow in favor of **`run-local-demo.sh`**, the **player app / tracker / simulator** split, staged release zips from **`tools/build-deploy.sh`**, and prerequisites (**Chia wallet 2.7.1+**, Rust/wasm-pack/pnpm). It documents **mainnet-only** Alpha 2, updated **`front-end/`** config paths, and removes the old “funds left on-chain after shutdown” warning. Legacy HTML anchors are preserved for external links.
> 
> The **Users Guide** and **Known Issues** align with Alpha 2: **CalPoker** and **Space Poker** as early releases, **Krunk** still coming soon, corrected **handshake** narrative (one on-chain spend bundle, multiple WalletConnect approvals), and several items marked **fixed in Alpha 2** (shutdown funds return, UI handshake/contrast). **Troubleshooting** is rewritten around native builds (WASM, pnpm, Chialisp hex, port **5801** tracker vs simulator conflict) instead of Docker.
> 
> **Space Poker** rules are rewritten to match the current implementation (single shared board, suitless hold’em, boost tiebreakers, on-chain street/actions). **California Poker** gets an Alpha 2 callout. New **`gaming-architecture.md`** explains state channels, coin hierarchy, potato protocol, referee/handlers, connectivity, and WalletConnect integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0256288182198b5682457130df9e57a8605a5d15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->