### PR TITLE
docs: capitalize GitHub consistently in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you would like to contribute localization translations, please visit our [Cro
 
 ## Website
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator, and deployed with Github Pages.
+This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator, and deployed with GitHub Pages.
 
 ### Installation
 
@@ -42,9 +42,9 @@ $ npm run serve
 
 This command serves the static content in the `build` directory.
 
-### Commands run in github CI
+### Commands run in GitHub CI
 
-These are the commands being run in the github CI, run them all locally in this order to ensure there are no issues building and serving the content prior to submitting a pr:
+These are the commands being run in the GitHub CI, run them all locally in this order to ensure there are no issues building and serving the content prior to submitting a pr:
 
 ```
 $ npm install


### PR DESCRIPTION
Tiny capitalization fix: 'github' → 'GitHub' in three places.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or build impact.
> 
> **Overview**
> Updates **README.md** prose to use the official **GitHub** capitalization in three spots: deployment with **GitHub Pages**, the **Commands run in GitHub CI** heading, and the sentence describing those CI commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a065e9da470a34e197630dc8c9dc55c76af60867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->