### PR TITLE
fix title on addresses page

### DIFF
--- a/docs/chia-blockchain/coin-set-model/addresses.md
+++ b/docs/chia-blockchain/coin-set-model/addresses.md
@@ -21,7 +21,7 @@ The blockchain consensus code does not operate with addresses; addresses are onl
 
 Spacescan.io has a handy bi-directional [bech32m \<\> puzzle hash converter](https://www.spacescan.io/xch/tools/puzzlehashconvertor).
 
-# Chia Burn Address
+## Chia Burn Address
 
 You can send unwanted tokens to this addresses to make them unspendable:
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/chia-blockchain/coin-set-model/addresses.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/chia-blockchain/coin-set-model/addresses.md
@@ -21,7 +21,7 @@ The blockchain consensus code does not operate with addresses; addresses are onl
 
 Spacescan.io has a handy bi-directional [bech32m \<\> puzzle hash converter](https://www.spacescan.io/xch/tools/puzzlehashconvertor).
 
-# Chia Burn Address
+## Chia Burn Address
 
 You can send unwanted tokens to this addresses to make them unspendable:
 


### PR DESCRIPTION
fixes https://github.com/Chia-Network/chia-docs/issues/800

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only heading fix with no runtime or behavioral impact.
> 
> **Overview**
> Fixes incorrect heading markup for **Chia Burn Address** on the coin-set addresses doc by changing `-# Chia Burn Address` to `## Chia Burn Address` in `addresses.md` and the matching zh-Hans translation file, so the section renders as a normal H2 in Docusaurus (addresses issue #800).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa5d4088c6f7587c5fef5b782fd283e3e23d713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->