### PR TITLE
docs(timelord): document non-localhost ASIC vdf config

### DIFF
--- a/docs/reference-client/install-and-setup/timelord-install.md
+++ b/docs/reference-client/install-and-setup/timelord-install.md
@@ -107,19 +107,35 @@ Main Machine (ASIC 1)  --------------------------
 For an ASIC cluster you will need to follow the below install steps on the main machine to include the chia node, timelord-only, and ASIC software processes are all being run on the main machine.  
 The additional ASIC hosts will only need the ASIC software installed (noted in the below install instructions).
 
-When the timelord and ASIC software run on different machines (not localhost-only), update `~/.chia/mainnet/config/config.yaml` before starting services:
+When the timelord and ASIC software run on different machines (not localhost-only), update `~/.chia/mainnet/config/config.yaml` on the **timelord host** before starting services:
 
-- On the machine running the Chia timelord, set `vdf_server` to listen on all interfaces: `0.0.0.0`.
-- Point `vdf_clients` at the IP address of each ASIC host so the timelord can reach the hardware VDF clients.
+- Set `timelord.vdf_server.host` to `0.0.0.0` so the timelord listens for remote `hw_vdf_client` TCP connections (default port `8000`).
+- Add each ASIC machine's LAN IP to `timelord.vdf_clients.ip`. The timelord accepts only VDF clients whose source IP appears in this list.
+- On each ASIC host, point `hw_vdf_client` at the timelord with `--ip <timelord-host-ip>` (see [ASIC HW VDF CLI](/reference-client/cli-reference/asic-hwvdf-cli)).
+- When using hardware VDF clients only, set `timelord_launcher.process_count` to `0` so the timelord launcher does not spawn local software `vdf_client` processes.
 
-Example using `yq` on the timelord host:
+Example `timelord` section (adjust IPs for your cluster):
 
-```bash
-yq -i '.timelord.vdf_server.host = "0.0.0.0"' ~/.chia/mainnet/config/config.yaml
-yq -i '.timelord_launcher.vdf_clients[0].host = "<asic-host-ip>"' ~/.chia/mainnet/config/config.yaml
+```yaml
+timelord:
+  vdf_server:
+    host: 0.0.0.0
+    port: 8000
+  vdf_clients:
+    ip:
+      - 127.0.0.1
+      - <asic-host-ip>
 ```
 
-Replace `<asic-host-ip>` with the LAN IP of the ASIC machine. Adjust the `vdf_clients` list if you run multiple ASIC hosts in a cluster.
+Replace `<asic-host-ip>` with the source IP of each ASIC machine. Add one entry per remote ASIC host.
+
+On each remote ASIC host:
+
+```bash
+hw_vdf_client --ip <timelord-host-ip> 8000 1
+```
+
+Use `1` for `N_VDFS` on cluster nodes that run a single engine; see the install steps below for localhost examples.
 
 ```bash
 # Install packages

--- a/docs/reference-client/install-and-setup/timelord-install.md
+++ b/docs/reference-client/install-and-setup/timelord-install.md
@@ -107,6 +107,20 @@ Main Machine (ASIC 1)  --------------------------
 For an ASIC cluster you will need to follow the below install steps on the main machine to include the chia node, timelord-only, and ASIC software processes are all being run on the main machine.  
 The additional ASIC hosts will only need the ASIC software installed (noted in the below install instructions).
 
+When the timelord and ASIC software run on different machines (not localhost-only), update `~/.chia/mainnet/config/config.yaml` before starting services:
+
+- On the machine running the Chia timelord, set `vdf_server` to listen on all interfaces: `0.0.0.0`.
+- Point `vdf_clients` at the IP address of each ASIC host so the timelord can reach the hardware VDF clients.
+
+Example using `yq` on the timelord host:
+
+```bash
+yq -i '.timelord.vdf_server.host = "0.0.0.0"' ~/.chia/mainnet/config/config.yaml
+yq -i '.timelord_launcher.vdf_clients[0].host = "<asic-host-ip>"' ~/.chia/mainnet/config/config.yaml
+```
+
+Replace `<asic-host-ip>` with the LAN IP of the ASIC machine. Adjust the `vdf_clients` list if you run multiple ASIC hosts in a cluster.
+
 ```bash
 # Install packages
 sudo apt-get update


### PR DESCRIPTION
Fixes #819

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or config defaults modified in the repository.
> 
> **Overview**
> Adds setup guidance for **ASIC timelord clusters** when the timelord and `hw_vdf_client` run on **separate hosts** (not localhost-only).
> 
> Operators are told to edit `~/.chia/mainnet/config/config.yaml` before starting services: bind **`timelord.vdf_server.host`** to **`0.0.0.0`** on the timelord machine, and set **`timelord_launcher.vdf_clients`** entries to each ASIC host’s LAN IP. The doc includes **`yq`** one-liners and notes extending the `vdf_clients` list for multi-ASIC clusters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db3ab844901e699ae12b29df6f2cb850f4cc600a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->