### PR TITLE
docs(contributing): add SSH commit signing instructions

### DIFF
--- a/docs/contribution/using-github.md
+++ b/docs/contribution/using-github.md
@@ -107,6 +107,20 @@ Right now, you have a fork of the chia-docs repository, but you do not have the 
 
 All Chia related Github repos require the signing of commits, follow the outlined process to setup automated commit signing for the Github Desktop Application.
 
+You can sign commits with **GPG** (below) or **SSH**. GitHub documents both in [About commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
+
+#### SSH commit signing
+
+:::info
+The below information has been adapted from the [GitHub docs on SSH commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification).
+:::
+
+1. [Generate a new SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) and add the public key to your GitHub account under **Settings → SSH and GPG keys**.
+2. [Tell Git to sign commits with SSH](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key): set `git config --global gpg.format ssh` and `git config --global user.signingkey` to your public key path (for example `~/.ssh/id_ed25519.pub`).
+3. Enable signing: `git config --global commit.gpgsign true` (Git uses this setting for SSH signing as well when `gpg.format` is `ssh`).
+
+SSH-signed commits show as **Verified** on GitHub when the signing key is on your account.
+
 #### Generating a New GPG Key
 
 :::info


### PR DESCRIPTION
Fixes #635

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor setup instructions; no application or security logic is modified.
> 
> **Overview**
> The **Setup Commit Signing** section in `using-github.md` now states that contributors can use **SSH** or **GPG**, with a link to GitHub’s commit signature verification docs.
> 
> A new **SSH commit signing** subsection (placed before the existing GPG steps) walks through generating an SSH key, adding it under **Settings → SSH and GPG keys**, configuring `gpg.format ssh`, `user.signingkey`, and `commit.gpgsign true`, and notes that commits show as **Verified** when the key is on the account. The GPG flow is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd57fc734dcdf30c2a45b9117bbad86784b0e1cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->