### PR TITLE
docs(cloud-wallet): clarify Step 10 checkmark is not a checkbox

### DIFF
--- a/docs/cloud-wallet/getting-started.md
+++ b/docs/cloud-wallet/getting-started.md
@@ -99,10 +99,10 @@ You cannot use both the Cloud Wallet and the Chia Signer app on the same device 
   <img src="/img/cloud-wallet/09_link_key.png" alt="Link your key to your vault" width="40%"/>
 </div>
 
-10. If a green check box appears over the QR code, then your signer app was successfully linked to your vault:
+10. When linking succeeds, a green checkmark appears over the QR code on the Cloud Wallet page (this is a status indicator, not a checkbox you need to click):
 
 <div style={{ textAlign: 'left' }}>
-  <img src="/img/cloud-wallet/10_key_linked.png" alt="Signer successfully linked" width="100%"/>
+  <img src="/img/cloud-wallet/10_key_linked.png" alt="Green checkmark indicating the signer was successfully linked" width="100%"/>
 </div>
 
 11. Next, copy the 24 words to a safe location. You will need to recall these words in order to recover your vault, so don't lose them.


### PR DESCRIPTION
Fixes #825

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and alt-text changes with no runtime or security impact.
> 
> **Overview**
> Updates **Step 10** in the Cloud Wallet getting-started guide so users know the green overlay on the QR code is a **success status indicator**, not an interactive checkbox.
> 
> The step text now names the Cloud Wallet page and explicitly says nothing needs to be clicked; the screenshot **alt text** is aligned with “checkmark” wording instead of implying a generic “linked” state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8aaf15f62f66a049eb3fcc5136ad79dc2da90bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->