### PR TITLE
Fix/93 rpc bigint warning

### DIFF
--- a/docs/reference-client/rpc-reference/full-node-rpc.md
+++ b/docs/reference-client/rpc-reference/full-node-rpc.md
@@ -948,6 +948,12 @@ Request Parameters: None
 
 :::
 
+:::note
+
+`blockchain_state.space` is a network-space estimate in bytes (`uint128` in the node). It can exceed `Number.MAX_SAFE_INTEGER` (2^53 - 1). JavaScript and other IEEE-754 JSON parsers may lose precision; use a bigint-capable parser or treat the value as a string. See [RPC overview — large integers](/reference-client/rpc-reference/rpc#large-integers-in-json-responses).
+
+:::
+
 <details>
 <summary>Example</summary>
 
@@ -3476,6 +3482,12 @@ Request Parameters:
 | :---------------------- | :--------- | :------- | :-------------------- |
 | older_block_header_hash | HEX STRING | True     | The start header hash |
 | newer_block_header_hash | HEX STRING | True     | The end header hash   |
+
+:::note
+
+The response `space` field is a netspace estimate in bytes (`uint128` in the node). Values often exceed `Number.MAX_SAFE_INTEGER` (2^53 - 1). JavaScript and other IEEE-754 JSON parsers may lose precision; use a bigint-capable parser or treat the value as a string. See [RPC overview — large integers](/reference-client/rpc-reference/rpc#large-integers-in-json-responses).
+
+:::
 
 <details>
 <summary>Example</summary>

--- a/docs/reference-client/rpc-reference/rpc.md
+++ b/docs/reference-client/rpc-reference/rpc.md
@@ -26,11 +26,12 @@ chia rpc wallet create_new_wallet '{\"wallet_type\": \"nft_wallet\"}'
 :::warning Large integers in JSON responses
 Some RPC responses include integers larger than `Number.MAX_SAFE_INTEGER` (2^53 - 1). Parsers that treat JSON numbers as IEEE-754 doubles may lose precision or fail.
 
-Routes that return especially large values include:
+Full node routes that return especially large values include:
 
-- `get_blockchain_state` (network space in the `BlockchainState` payload)
-- `get_network_space`
-- `get_all_puzzle_hashes`
+- `get_blockchain_state` (`blockchain_state.space`, a network-space estimate)
+- `get_network_space` (`space` in the response)
+
+The simulator full node also exposes `get_all_puzzle_hashes`, which can return large coin amounts in its `puzzle_hashes` map.
 
 When building clients in JavaScript or other languages with limited integer types, treat these fields as strings or use a bigint-capable JSON parser. Verify behavior against a live node if your stack coerces JSON numbers automatically.
 :::

--- a/docs/reference-client/rpc-reference/rpc.md
+++ b/docs/reference-client/rpc-reference/rpc.md
@@ -23,17 +23,19 @@ chia rpc wallet create_new_wallet '{\"wallet_type\": \"nft_wallet\"}'
 
 </details>
 
+<span id="large-integers-in-json-responses"></span>
+
 :::warning Large integers in JSON responses
 Some RPC responses include integers larger than `Number.MAX_SAFE_INTEGER` (2^53 - 1). Parsers that treat JSON numbers as IEEE-754 doubles may lose precision or fail.
 
 Full node routes that return especially large values include:
 
-- `get_blockchain_state` (`blockchain_state.space`, a network-space estimate)
-- `get_network_space` (`space` in the response)
+- [`get_blockchain_state`](/reference-client/rpc-reference/full-node-rpc#get_blockchain_state) (`blockchain_state.space`, a network-space estimate)
+- [`get_network_space`](/reference-client/rpc-reference/full-node-rpc#get_network_space) (`space` in the response)
 
-The simulator full node also exposes `get_all_puzzle_hashes`, which can return large coin amounts in its `puzzle_hashes` map.
+The simulator full node also exposes [`get_all_puzzle_hashes`](/reference-client/rpc-reference/simulator-rpc#get_all_puzzle_hashes), which can return large coin amounts in its `puzzle_hashes` map.
 
-When building clients in JavaScript or other languages with limited integer types, treat these fields as strings or use a bigint-capable JSON parser. Verify behavior against a live node if your stack coerces JSON numbers automatically.
+Each affected endpoint documents the precise fields on its reference page. When building clients in JavaScript or other languages with limited integer types, treat these fields as strings or use a bigint-capable JSON parser. Verify behavior against a live node if your stack coerces JSON numbers automatically.
 :::
 
 The Chia node and services come with a JSON RPC API server that allows you to access information and control the services.

--- a/docs/reference-client/rpc-reference/rpc.md
+++ b/docs/reference-client/rpc-reference/rpc.md
@@ -23,6 +23,18 @@ chia rpc wallet create_new_wallet '{\"wallet_type\": \"nft_wallet\"}'
 
 </details>
 
+:::warning Large integers in JSON responses
+Some RPC responses include integers larger than `Number.MAX_SAFE_INTEGER` (2^53 - 1). Parsers that treat JSON numbers as IEEE-754 doubles may lose precision or fail.
+
+Routes that return especially large values include:
+
+- `get_blockchain_state` (network space in the `BlockchainState` payload)
+- `get_network_space`
+- `get_all_puzzle_hashes`
+
+When building clients in JavaScript or other languages with limited integer types, treat these fields as strings or use a bigint-capable JSON parser. Verify behavior against a live node if your stack coerces JSON numbers automatically.
+:::
+
 The Chia node and services come with a JSON RPC API server that allows you to access information and control the services.
 These are accessible via HTTP, WebSockets, or via client SDKs.
 The ports can be configured in `~/.chia/mainnet/config/config.yaml`.

--- a/docs/reference-client/rpc-reference/simulator-rpc.md
+++ b/docs/reference-client/rpc-reference/simulator-rpc.md
@@ -293,6 +293,12 @@ Options:
 
 Request Parameters: None
 
+:::note
+
+Coin amounts in the `puzzle_hashes` map can exceed `Number.MAX_SAFE_INTEGER` (2^53 - 1). JavaScript and other IEEE-754 JSON parsers may lose precision; use a bigint-capable parser or treat these values as strings. See [RPC overview — large integers](/reference-client/rpc-reference/rpc#large-integers-in-json-responses).
+
+:::
+
 <details>
 <summary>Example</summary>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> Adds documentation so RPC clients know when JSON numeric fields can exceed safe integer limits in JavaScript and similar runtimes.
> 
> The **RPC overview** (`rpc.md`) gains a new **Large integers in JSON responses** warning with an anchor link. It lists affected routes (`get_blockchain_state`, `get_network_space`, simulator `get_all_puzzle_hashes`) and recommends bigint-capable parsers or string handling.
> 
> **Per-endpoint notes** on `full-node-rpc.md` call out `blockchain_state.space` and `get_network_space`’s `space` field (`uint128` netspace in bytes). **Simulator RPC** docs add a matching note for large coin amounts in `get_all_puzzle_hashes`’s `puzzle_hashes` map. Each endpoint note links back to the overview section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a108fed3f3867e35a4ded503e7cad73eb1d71ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->