### PR TITLE
Update Managed Files

### DIFF
--- a/.github/workflows/check-commit-signing.yml
+++ b/.github/workflows/check-commit-signing.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dependency-cursor-review.yml
+++ b/.github/workflows/dependency-cursor-review.yml
@@ -72,7 +72,7 @@ jobs:
             core.setOutput('head_sha', pr.head?.sha || '');
 
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.target_pr.outputs.head_sha }}
           persist-credentials: false
@@ -242,7 +242,7 @@ jobs:
         run: mkdir -p ".upstream-dependency"
 
       - name: Checkout upstream repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           repository: ${{ steps.dependabot_context.outputs.upstream_repo }}
           path: .upstream-dependency

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
 
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v5.0.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only dependency pin relaxation on checkout; no application or security logic changes.
> 
> **Overview**
> Updates **managed** GitHub Actions workflows to use `actions/checkout@v6` instead of the patch-pinned `actions/checkout@v6.0.2`.
> 
> **check-commit-signing**, **dependency-cursor-review** (repo and upstream checkouts), and **dependency-review** are the only files touched. Workflow behavior is unchanged aside from following the `v6` floating major ref for checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 803f3a81a23335e78fb2421fd8cc8ea2a60035f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->