### PR TITLE
Update ingress annotations in review.yaml.j2

### DIFF
--- a/k8s/review.yaml.j2
+++ b/k8s/review.yaml.j2
@@ -7,8 +7,9 @@ service:
 
 ingress:
   enabled: true
+  className: contour
   annotations:
-    ingress.kubernetes.io/ssl-redirect: "true"
+    ingress.kubernetes.io/force-ssl-redirect: "true"
   hosts:
     - host: {{ REVIEW_SLUG }}.docs.chia.net
       paths:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small review-only Helm/Jinja ingress tweak with no auth or data-path changes; main risk is mis-routed traffic if Contour or the annotation is wrong for the cluster.
> 
> **Overview**
> Review-environment ingress is now explicitly wired to **Contour** via `className: contour`, and the SSL annotation is switched from `ssl-redirect` to **`force-ssl-redirect`** so HTTP requests are always redirected to HTTPS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d38a8e0ebad10960a5eb5cce4d896bce4ef0229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->