### PR TITLE
Update node syncing troubleshooting documentation

### DIFF
--- a/docs/reference-client/troubleshooting/node-syncing.md
+++ b/docs/reference-client/troubleshooting/node-syncing.md
@@ -154,10 +154,6 @@ values={[
     Note: please only use the CNI operated nodes as a last resort for connecting to peers, these nodes might be running different client versions and are not intended to be used as trusted full nodes.
     - CNI Operated Full Node: `node.chia.net`
 
-    Additionally, you can also visit either of the below websites that are frequently updated with available nodes listening on port 8444:
-    - [ChiaNodes.com](https://ChiaNodes.com)
-    - [chia.keva.app](https://chia.keva.app)
-
   </TabItem>
   <TabItem value="testnet11">
 


### PR DESCRIPTION
Removed outdated links to external node resources.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates **node syncing** troubleshooting so the **Mainnet** tab no longer points readers to third-party node lists (**ChiaNodes.com**, **chia.keva.app**).
> 
> Official guidance in that section is unchanged: mainnet introducer **`introducer.chia.net:8444`**, the CNI full-node note, and **`node.chia.net`** as a last-resort peer remain documented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28f97356d0cb7bc3f638059fa0a024f05ea67cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->