### PR TITLE
Update supported hardware list

### DIFF
--- a/docs/reference-client/plotting/plotting-hardware.md
+++ b/docs/reference-client/plotting/plotting-hardware.md
@@ -129,17 +129,25 @@ Unfortunately, we may not be able to offer support if your machine does not fall
 
 Operating Systems
 
-- Ubuntu 20.04.6 LTS
-- Ubuntu 22.04.02 LTS
-- Ubuntu 23.04
-- RHEL 7.4
-- RHEL 8.7
-- RHEL 9.1
-- Windows 10 version 22H2
-- Windows 11 version 21H2
-- Windows 11 version 22H2
-- Windows Server 2022
-- Windows Server 2019 (version 1809)
+[Ubuntu](https://ubuntu.com/about/release-cycle)
+
+- Ubuntu 22.04 LTS (until May 2027)
+- Ubuntu 24.04 LTS (until May 2029)
+- Ubuntu 26.04 LTS (until May 2031)
+
+[Red Hat Enterprise Linux](https://access.redhat.com/support/policy/updates/errata_legacy#Planning_Guides)
+
+- RHEL 8.10 (until 3Q 2029)
+- RHEL 9.10 (until 2Q 2032)
+- RHEL 10.3 - 10.9 (until 2027-30)
+- RHEL 10.10 (until 2Q 2035)
+
+[Windows](https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions)
+
+- Windows 11 version 25H2 (until 12 Oct 2027)
+- Windows 11 version 26H1 (until 14 Mar 2028)
+- Windows Server 2022 (until 14 Oct 2031)
+- Windows Server 2025 (Until 14 Nov 2034)
 
 Systems
 

--- a/docs/reference-client/rpc-reference/rpc.md
+++ b/docs/reference-client/rpc-reference/rpc.md
@@ -25,7 +25,10 @@ chia rpc wallet create_new_wallet '{\"wallet_type\": \"nft_wallet\"}'
 
 <span id="large-integers-in-json-responses"></span>
 
-:::warning Large integers in JSON responses
+:::warning
+
+### Large integers in JSON responses
+
 Some RPC responses include integers larger than `Number.MAX_SAFE_INTEGER` (2^53 - 1). Parsers that treat JSON numbers as IEEE-754 doubles may lose precision or fail.
 
 Full node routes that return especially large values include:

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference-client/rpc-reference/farmer-rpc.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference-client/rpc-reference/farmer-rpc.md
@@ -493,6 +493,68 @@ Response:
 
 ---
 
+### `connect_to_solver`
+
+Functionality: Disconnect any existing SOLVER peer connections, then open a new client connection to the Solver service at the given host and port. The Solver turns partial proofs from harvesters into full proofs of space. That pipeline is for V2 plots used with Proof of Space 2 (PoS2). Legacy PoS1 farming with classic V1 plots does not use it; the harvester already returns a complete proof.
+
+:::info PoS2 is still months away for most farmers
+
+Proof of Space 2 and V2 plot farming are not yet what typical mainnet farmers run day to day; wider activation is still months away. Until you are farming V2 plots under PoS2, you do not need a Solver connection. This RPC does nothing useful for PoS1 or classic plots; it is documented because the client exposes the route for when PoS2 and V2 farming become relevant.
+
+For milestone dates and rollout expectations, see the [Proof of Space 2 timeline](/chia-blockchain/consensus/proof-of-space-2.0/new-proof-timeline). The PoS2 proof format is specified in [CHIP-48](https://github.com/Chia-Network/chips/pull/160); activation timing and related hard-fork items are in [CHIP-49](https://github.com/Chia-Network/chips/pull/161).
+
+:::
+
+Usage: chia rpc farmer [OPTIONS] connect_to_solver [REQUEST]
+
+Options:
+
+| Short Command | Long Command | Type     | Required | Description                                                                           |
+| :------------ | :----------- | :------- | :------- | :------------------------------------------------------------------------------------ |
+| -j            | --json-file  | FILENAME | False    | Optionally instead of REQUEST you can provide a json file containing the request data |
+| -h            | --help       | None     | False    | Show a help message and exit                                                          |
+
+Request Parameters:
+
+| Flag | Type    | Required | Description                               |
+| :--- | :------ | :------- | :---------------------------------------- |
+| host | STRING  | True     | Hostname or IP address of the solver peer |
+| port | INTEGER | True     | Port of the solver (`peer_server_port`)   |
+
+:::note
+
+Use `port` as the solver **peer** listening port (`solver.port` in `config.yaml`; **8666** by default). That is different from the solver JSON-RPC TLS port (`solver.rpc_port`, **8667**). For solver HTTP endpoints (`chia rpc solver …`), see [Solver RPC](/reference-client/rpc-reference/solver-rpc).
+
+:::
+
+<details>
+<summary>Example</summary>
+
+```json
+chia rpc farmer connect_to_solver '{"host": "127.0.0.1", "port": 8666}'
+```
+
+Response (success):
+
+```json
+{
+  "success": true
+}
+```
+
+Response (could not connect):
+
+```json
+{
+  "success": false,
+  "error": "Could not connect to solver at 127.0.0.1:8666"
+}
+```
+
+</details>
+
+---
+
 ### `get_routes`
 
 Functionality: List all available RPC routes
@@ -533,12 +595,18 @@ Response:
     "/get_harvester_plots_keys_missing",
     "/get_harvester_plots_duplicates",
     "/get_pool_login_link",
+    "/connect_to_solver",
+    "/get_network_info",
     "/get_connections",
     "/open_connection",
     "/close_connection",
     "/stop_node",
     "/get_routes",
-    "/healthz"
+    "/get_version",
+    "/healthz",
+    "/get_log_level",
+    "/set_log_level",
+    "/reset_log_level"
   ],
   "success": true
 }


### PR DESCRIPTION
Also fix some broken links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> Updates the **compressed plotting** “Most tested” OS section from a flat list of versions to grouped Ubuntu, RHEL, and Windows entries with **official policy/wiki links** and **support end dates**, replacing older releases (e.g. Ubuntu 20.04/23.04, RHEL 7–9.1, Win10/older Win11) with current LTS/current-channel builds.
> 
> On the RPC overview page, the **large integers in JSON** callout is reformatted so the Docusaurus `:::warning` block uses a proper heading instead of a broken inline title.
> 
> The **Simplified Chinese** Farmer RPC page gains full documentation for **`connect_to_solver`** (PoS2/V2 solver peer vs RPC port) and refreshes the **`get_routes`** example to include newer shared routes (`/connect_to_solver`, `/get_network_info`, `/get_version`, log-level routes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00f4e3e5c530442c3cd28fae80bcd112cfb74110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->