### PR TITLE
[CHIA-4413] Update CLI reference for 2.7.4 wallet command framework migration

### DIFF
--- a/docs/reference-client/cli-reference/did-cli.md
+++ b/docs/reference-client/cli-reference/did-cli.md
@@ -26,6 +26,17 @@ Options:
 | -n            | --name            | TEXT    | False    | Set the DID wallet name [default: None]                                                                  |
 | -a            | --amount          | INTEGER | False    | Set the DID amount in mojos. Value must be an odd number. [default: 1]                                   |
 | -m            | --fee             | TEXT    | False    | Set the fees per transaction, in XCH. [default: 0]                                                       |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
+|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
 | -h            | --help            | None    | False    | Show a help message and exit.                                                                            |
 
 <details>
@@ -211,6 +222,17 @@ Options:
 | -i            | --id                   | INTEGER | True     | ID of the wallet to use                                                                                  |
 | -pa           | --puzzle_announcements | TEXT    | False    | The list of puzzle announcement hex strings, split by commas (`,`)                                       |
 | -ca           | --coin_announcements   | TEXT    | False    | The list of coin announcement hex strings, split by commas (`,`)                                         |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
+|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
 | -h            | --help                 | None    | False    | Show a help message and exit.                                                                            |
 
 <details>
@@ -366,6 +388,16 @@ Options:
 | -r            | --reset_recovery  | None    | False    | Set this flag if you want to reset the recovery DID settings (they will not be transferred with the DID) |
 | -m            | --fee             | TEXT    | False    | An optional transaction fee, in XCH                                                                      |
 |               | --reuse           | None    | False    | Reuse existing address for the change                                                                    |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
 | -h            | --help            | None    | False    | Show a help message and exit                                                                             |
 
 <details>
@@ -441,6 +473,16 @@ Options:
 | -i            | --id              | INTEGER | True     | ID of the DID wallet to use                                                                              |
 | -m            | --metadata        | TEXT    | True     | The new whole metadata in json format                                                                    |
 |               | --reuse           | None    | False    | Set this flag to reuse existing address for the change                                                   |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
 | -h            | --help            | None    | False    | Show a help message and exit                                                                             |
 
 ---

--- a/docs/reference-client/cli-reference/did-cli.md
+++ b/docs/reference-client/cli-reference/did-cli.md
@@ -19,13 +19,13 @@ Usage: `chia wallet did create [OPTIONS]`
 
 Options:
 
-| Short Command | Long Command      | Type    | Required | Description                                                                                              |
-| :------------ | :---------------- | :------ | :------- | :------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
-| -f            | --fingerprint     | INTEGER | False    | Set the fingerprint to specify which wallet to use                                                       |
-| -n            | --name            | TEXT    | False    | Set the DID wallet name [default: None]                                                                  |
-| -a            | --amount          | INTEGER | False    | Set the DID amount in mojos. Value must be an odd number. [default: 1]                                   |
-| -m            | --fee             | TEXT    | False    | Set the fees per transaction, in XCH. [default: 0]                                                       |
+| Short Command | Long Command            | Type      | Required | Description                                                                                              |
+| :------------ | :---------------------- | :-------- | :------- | :------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port       | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
+| -f            | --fingerprint           | INTEGER   | False    | Set the fingerprint to specify which wallet to use                                                       |
+| -n            | --name                  | TEXT      | False    | Set the DID wallet name [default: None]                                                                  |
+| -a            | --amount                | INTEGER   | False    | Set the DID amount in mojos. Value must be an odd number. [default: 1]                                   |
+| -m            | --fee                   | TEXT      | False    | Set the fees per transaction, in XCH. [default: 0]                                                       |
 |               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
 |               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
 |               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
@@ -37,7 +37,7 @@ Options:
 | -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
 | -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
 |               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
-| -h            | --help            | None    | False    | Show a help message and exit.                                                                            |
+| -h            | --help                  | None      | False    | Show a help message and exit.                                                                            |
 
 <details>
 <summary>Example</summary>
@@ -215,13 +215,13 @@ Usage: `chia wallet did message_spend [OPTIONS]`
 
 Options:
 
-| Short Command | Long Command           | Type    | Required | Description                                                                                              |
-| :------------ | :--------------------- | :------ | :------- | :------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port      | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
-| -f            | --fingerprint          | INTEGER | False    | Set the fingerprint to specify which wallet to use                                                       |
-| -i            | --id                   | INTEGER | True     | ID of the wallet to use                                                                                  |
-| -pa           | --puzzle_announcements | TEXT    | False    | The list of puzzle announcement hex strings, split by commas (`,`)                                       |
-| -ca           | --coin_announcements   | TEXT    | False    | The list of coin announcement hex strings, split by commas (`,`)                                         |
+| Short Command | Long Command            | Type      | Required | Description                                                                                              |
+| :------------ | :---------------------- | :-------- | :------- | :------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port       | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
+| -f            | --fingerprint           | INTEGER   | False    | Set the fingerprint to specify which wallet to use                                                       |
+| -i            | --id                    | INTEGER   | True     | ID of the wallet to use                                                                                  |
+| -pa           | --puzzle_announcements  | TEXT      | False    | The list of puzzle announcement hex strings, split by commas (`,`)                                       |
+| -ca           | --coin_announcements    | TEXT      | False    | The list of coin announcement hex strings, split by commas (`,`)                                         |
 |               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
 |               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
 |               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
@@ -233,7 +233,7 @@ Options:
 | -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
 | -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
 |               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
-| -h            | --help                 | None    | False    | Show a help message and exit.                                                                            |
+| -h            | --help                  | None      | False    | Show a help message and exit.                                                                            |
 
 <details>
 <summary>Example</summary>
@@ -379,26 +379,26 @@ Usage: `chia wallet did transfer [OPTIONS]`
 
 Options:
 
-| Short Command | Long Command      | Type    | Required | Description                                                                                              |
-| :------------ | :---------------- | :------ | :------- | :------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
-| -f            | --fingerprint     | INTEGER | False    | Set the fingerprint to specify which wallet to use                                                       |
-| -i            | --id              | INTEGER | True     | ID of the DID wallet to transfer                                                                         |
-| -ta           | --target-address  | TEXT    | True     | Target recipient wallet address                                                                          |
-| -r            | --reset_recovery  | None    | False    | Set this flag if you want to reset the recovery DID settings (they will not be transferred with the DID) |
-| -m            | --fee             | TEXT    | False    | An optional transaction fee, in XCH                                                                      |
-|               | --reuse           | None    | False    | Reuse existing address for the change                                                                    |
-|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
-|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
-|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
-|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
-|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
-|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
-|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
-|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
-| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
-| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
-| -h            | --help            | None    | False    | Show a help message and exit                                                                             |
+| Short Command | Long Command           | Type      | Required | Description                                                                                              |
+| :------------ | :--------------------- | :-------- | :------- | :------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port      | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
+| -f            | --fingerprint          | INTEGER   | False    | Set the fingerprint to specify which wallet to use                                                       |
+| -i            | --id                   | INTEGER   | True     | ID of the DID wallet to transfer                                                                         |
+| -ta           | --target-address       | TEXT      | True     | Target recipient wallet address                                                                          |
+| -r            | --reset_recovery       | None      | False    | Set this flag if you want to reset the recovery DID settings (they will not be transferred with the DID) |
+| -m            | --fee                  | TEXT      | False    | An optional transaction fee, in XCH                                                                      |
+|               | --reuse                | None      | False    | Reuse existing address for the change                                                                    |
+|               | --push / --no-push     | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at             | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at           | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin         | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin         | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin         | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount       | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount      | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount      | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
+| -h            | --help                 | None      | False    | Show a help message and exit                                                                             |
 
 <details>
    <summary>Example</summary>
@@ -466,23 +466,23 @@ Usage: `chia wallet did update_metadata [OPTIONS]`
 
 Options:
 
-| Short Command | Long Command      | Type    | Required | Description                                                                                              |
-| :------------ | :---------------- | :------ | :------- | :------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
-| -f            | --fingerprint     | INTEGER | False    | Set the fingerprint to specify which wallet to use                                                       |
-| -i            | --id              | INTEGER | True     | ID of the DID wallet to use                                                                              |
-| -m            | --metadata        | TEXT    | True     | The new whole metadata in json format                                                                    |
-|               | --reuse           | None    | False    | Set this flag to reuse existing address for the change                                                   |
-|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
-|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
-|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
-|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
-|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
-|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
-|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
-|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
-| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
-| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
-| -h            | --help            | None    | False    | Show a help message and exit                                                                             |
+| Short Command | Long Command           | Type      | Required | Description                                                                                              |
+| :------------ | :--------------------- | :-------- | :------- | :------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port      | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
+| -f            | --fingerprint          | INTEGER   | False    | Set the fingerprint to specify which wallet to use                                                       |
+| -i            | --id                   | INTEGER   | True     | ID of the DID wallet to use                                                                              |
+| -m            | --metadata             | TEXT      | True     | The new whole metadata in json format                                                                    |
+|               | --reuse                | None      | False    | Set this flag to reuse existing address for the change                                                   |
+|               | --push / --no-push     | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at             | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at           | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin         | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin         | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin         | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount       | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount      | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount      | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
+| -h            | --help                 | None      | False    | Show a help message and exit                                                                             |
 
 ---

--- a/docs/reference-client/cli-reference/nft-cli.md
+++ b/docs/reference-client/cli-reference/nft-cli.md
@@ -131,6 +131,17 @@ Options:
 | -et           | --edition-total               | INTEGER | False    | NFT edition total number [default: 1]                                                                    |
 | -m            | --fee                         | TEXT    | False    | Set the fees per transaction, in XCH [default: 0]                                                        |
 |               | --no-did-ownership            | None    | False    | Disable DID ownership support. If this flag is not set, then DID ownership is supported by default       |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
+|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
 | -h            | --help                        | None    | False    | Show a help message and exit                                                                             |
 
 <details>
@@ -317,6 +328,17 @@ Options:
 | -di           | --did-id          | TEXT    | True     | DID ID to set on the NFT                                                                                 |
 | -ni           | --nft-coin-id     | TEXT    | True     | Coin ID of the NFT coin to set the DID on                                                                |
 | -m            | --fee             | TEXT    | False    | Set the fees per transaction, in XCH [default: 0]                                                        |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
+|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
 | -h            | --help            | None    | False    | Show a help message and exit                                                                             |
 
 <details>
@@ -643,6 +665,17 @@ Options:
 | -ni           | --nft-coin-id     | TEXT    | True     | Id of the NFT coin to transfer                                                                           |
 | -ta           | --target-address  | TEXT    | True     | Target recipient wallet address                                                                          |
 | -m            | --fee             | TEXT    | False    | Set the fees per transaction, in XCH. [default: 0]                                                       |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
+|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
 | -h            | --help            | None    | False    | Show a help message and exit                                                                             |
 
 <details>
@@ -723,6 +756,17 @@ Options:
 | -mu           | --metadata-uri    | TEXT    | True (see INFO) | Metadata URI to add to the NFT                                                                           |
 | -lu           | --license-uri     | TEXT    | True (see INFO) | License URI to add to the NFT                                                                            |
 | -m            | --fee             | TEXT    | False           | Set the fees per transaction, in XCH. [default: 0]                                                       |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
+|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
 | -h            | --help            | None    | False           | Show a help message and exit                                                                             |
 
 <details>
@@ -788,6 +832,17 @@ Options:
 | -di           | --did-id          | TEXT    | True     | DID Id to set on the NFT                                                                                 |
 | -ni           | --nft-coin-id     | TEXT    | True     | Id of the NFT coin on which to set the DID                                                               |
 | -m            | --fee             | TEXT    | False    | Set the fees per transaction, in XCH. [default: 0]                                                       |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
+|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
 | -h            | --help            | None    | False    | Show a help message and exit                                                                             |
 
 <details>

--- a/docs/reference-client/cli-reference/nft-cli.md
+++ b/docs/reference-client/cli-reference/nft-cli.md
@@ -113,36 +113,36 @@ Usage: chia wallet nft mint [OPTIONS]
 
 Options:
 
-| Short Command | Long Command                  | Type    | Required | Description                                                                                              |
-| :------------ | :---------------------------- | :------ | :------- | :------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port             | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
-| -f            | --fingerprint                 | INTEGER | False    | Set the fingerprint to specify which wallet to use                                                       |
-| -i            | --id                          | INTEGER | True     | Id of the NFT wallet to use                                                                              |
-| -u            | --uris                        | TEXT    | True     | Comma separated list of content URIs                                                                     |
-| -nh           | --hash                        | TEXT    | True     | NFT content hash                                                                                         |
-| -mu           | --metadata-uris               | TEXT    | False    | Comma separated list of metadata URIs                                                                    |
-| -mh           | --metadata-hash               | TEXT    | False    | NFT metadata hash                                                                                        |
-| -lu           | --license-uris                | TEXT    | False    | Comma separated list of license URIs                                                                     |
-| -lh           | --license-hash                | TEXT    | False    | NFT license hash                                                                                         |
-| -ra           | --royalty-address             | TEXT    | False    | Royalty address                                                                                          |
-| -rp           | --royalty-percentage-fraction | INTEGER | False    | NFT royalty percentage fraction in basis points. Example: 175 would represent 1.75% [default: 0]         |
-| -ta           | --target-address              | TEXT    | False    | Target address                                                                                           |
-| -en           | --edition-number              | INTEGER | False    | NFT edition number [default: 1]                                                                          |
-| -et           | --edition-total               | INTEGER | False    | NFT edition total number [default: 1]                                                                    |
-| -m            | --fee                         | TEXT    | False    | Set the fees per transaction, in XCH [default: 0]                                                        |
-|               | --no-did-ownership            | None    | False    | Disable DID ownership support. If this flag is not set, then DID ownership is supported by default       |
-|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
-|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
-|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
-|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
-|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
-|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
-|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
-|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
-| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
-| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
-|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
-| -h            | --help                        | None    | False    | Show a help message and exit                                                                             |
+| Short Command | Long Command                  | Type      | Required | Description                                                                                              |
+| :------------ | :---------------------------- | :-------- | :------- | :------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port             | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
+| -f            | --fingerprint                 | INTEGER   | False    | Set the fingerprint to specify which wallet to use                                                       |
+| -i            | --id                          | INTEGER   | True     | Id of the NFT wallet to use                                                                              |
+| -u            | --uris                        | TEXT      | True     | Comma separated list of content URIs                                                                     |
+| -nh           | --hash                        | TEXT      | True     | NFT content hash                                                                                         |
+| -mu           | --metadata-uris               | TEXT      | False    | Comma separated list of metadata URIs                                                                    |
+| -mh           | --metadata-hash               | TEXT      | False    | NFT metadata hash                                                                                        |
+| -lu           | --license-uris                | TEXT      | False    | Comma separated list of license URIs                                                                     |
+| -lh           | --license-hash                | TEXT      | False    | NFT license hash                                                                                         |
+| -ra           | --royalty-address             | TEXT      | False    | Royalty address                                                                                          |
+| -rp           | --royalty-percentage-fraction | INTEGER   | False    | NFT royalty percentage fraction in basis points. Example: 175 would represent 1.75% [default: 0]         |
+| -ta           | --target-address              | TEXT      | False    | Target address                                                                                           |
+| -en           | --edition-number              | INTEGER   | False    | NFT edition number [default: 1]                                                                          |
+| -et           | --edition-total               | INTEGER   | False    | NFT edition total number [default: 1]                                                                    |
+| -m            | --fee                         | TEXT      | False    | Set the fees per transaction, in XCH [default: 0]                                                        |
+|               | --no-did-ownership            | None      | False    | Disable DID ownership support. If this flag is not set, then DID ownership is supported by default       |
+|               | --push / --no-push            | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out        | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at                    | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at                  | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin                | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin                | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin                | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount              | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount             | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount             | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
+|               | --reuse / --new-address       | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
+| -h            | --help                        | None      | False    | Show a help message and exit                                                                             |
 
 <details>
    <summary>Example 1 - Mint an NFT that is not associated with a DID</summary>
@@ -320,14 +320,14 @@ Usage: chia wallet nft set_did [OPTIONS]
 
 Options:
 
-| Short Command | Long Command      | Type    | Required | Description                                                                                              |
-| :------------ | :---------------- | :------ | :------- | :------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
-| -f            | --fingerprint     | INTEGER | False    | Set the fingerprint to specify which wallet to use                                                       |
-| -i            | --id              | INTEGER | True     | Id of the NFT wallet to use                                                                              |
-| -di           | --did-id          | TEXT    | True     | DID ID to set on the NFT                                                                                 |
-| -ni           | --nft-coin-id     | TEXT    | True     | Coin ID of the NFT coin to set the DID on                                                                |
-| -m            | --fee             | TEXT    | False    | Set the fees per transaction, in XCH [default: 0]                                                        |
+| Short Command | Long Command            | Type      | Required | Description                                                                                              |
+| :------------ | :---------------------- | :-------- | :------- | :------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port       | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
+| -f            | --fingerprint           | INTEGER   | False    | Set the fingerprint to specify which wallet to use                                                       |
+| -i            | --id                    | INTEGER   | True     | Id of the NFT wallet to use                                                                              |
+| -di           | --did-id                | TEXT      | True     | DID ID to set on the NFT                                                                                 |
+| -ni           | --nft-coin-id           | TEXT      | True     | Coin ID of the NFT coin to set the DID on                                                                |
+| -m            | --fee                   | TEXT      | False    | Set the fees per transaction, in XCH [default: 0]                                                        |
 |               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
 |               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
 |               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
@@ -339,7 +339,7 @@ Options:
 | -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
 | -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
 |               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
-| -h            | --help            | None    | False    | Show a help message and exit                                                                             |
+| -h            | --help                  | None      | False    | Show a help message and exit                                                                             |
 
 <details>
    <summary>Example</summary>
@@ -657,14 +657,14 @@ Usage: chia wallet nft transfer [OPTIONS]
 
 Options:
 
-| Short Command | Long Command      | Type    | Required | Description                                                                                              |
-| :------------ | :---------------- | :------ | :------- | :------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
-| -f            | --fingerprint     | INTEGER | False    | Set the fingerprint to specify which wallet to use                                                       |
-| -i            | --id              | INTEGER | True     | Id of the NFT wallet to use                                                                              |
-| -ni           | --nft-coin-id     | TEXT    | True     | Id of the NFT coin to transfer                                                                           |
-| -ta           | --target-address  | TEXT    | True     | Target recipient wallet address                                                                          |
-| -m            | --fee             | TEXT    | False    | Set the fees per transaction, in XCH. [default: 0]                                                       |
+| Short Command | Long Command            | Type      | Required | Description                                                                                              |
+| :------------ | :---------------------- | :-------- | :------- | :------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port       | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
+| -f            | --fingerprint           | INTEGER   | False    | Set the fingerprint to specify which wallet to use                                                       |
+| -i            | --id                    | INTEGER   | True     | Id of the NFT wallet to use                                                                              |
+| -ni           | --nft-coin-id           | TEXT      | True     | Id of the NFT coin to transfer                                                                           |
+| -ta           | --target-address        | TEXT      | True     | Target recipient wallet address                                                                          |
+| -m            | --fee                   | TEXT      | False    | Set the fees per transaction, in XCH. [default: 0]                                                       |
 |               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
 |               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
 |               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
@@ -676,7 +676,7 @@ Options:
 | -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
 | -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
 |               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
-| -h            | --help            | None    | False    | Show a help message and exit                                                                             |
+| -h            | --help                  | None      | False    | Show a help message and exit                                                                             |
 
 <details>
 <summary>Example 1 - Send an NFT from a wallet not associated with a DID</summary>
@@ -746,28 +746,28 @@ Usage: chia wallet nft add_uri [OPTIONS]
 
 Options:
 
-| Short Command | Long Command      | Type    | Required        | Description                                                                                              |
-| :------------ | :---------------- | :------ | :-------------- | :------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port | INTEGER | False           | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
-| -f            | --fingerprint     | INTEGER | False           | Set the fingerprint to specify which wallet to use                                                       |
-| -i            | --id              | INTEGER | True            | Id of the NFT wallet to use                                                                              |
-| -ni           | --nft-coin-id     | TEXT    | True            | Id of the NFT coin to update                                                                             |
-| -u            | --uri             | TEXT    | True (see INFO) | Data URI to add to the NFT                                                                               |
-| -mu           | --metadata-uri    | TEXT    | True (see INFO) | Metadata URI to add to the NFT                                                                           |
-| -lu           | --license-uri     | TEXT    | True (see INFO) | License URI to add to the NFT                                                                            |
-| -m            | --fee             | TEXT    | False           | Set the fees per transaction, in XCH. [default: 0]                                                       |
-|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
-|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
-|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
-|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
-|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
-|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
-|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
-|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
-| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
-| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
-|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
-| -h            | --help            | None    | False           | Show a help message and exit                                                                             |
+| Short Command | Long Command            | Type      | Required        | Description                                                                                              |
+| :------------ | :---------------------- | :-------- | :-------------- | :------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port       | INTEGER   | False           | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
+| -f            | --fingerprint           | INTEGER   | False           | Set the fingerprint to specify which wallet to use                                                       |
+| -i            | --id                    | INTEGER   | True            | Id of the NFT wallet to use                                                                              |
+| -ni           | --nft-coin-id           | TEXT      | True            | Id of the NFT coin to update                                                                             |
+| -u            | --uri                   | TEXT      | True (see INFO) | Data URI to add to the NFT                                                                               |
+| -mu           | --metadata-uri          | TEXT      | True (see INFO) | Metadata URI to add to the NFT                                                                           |
+| -lu           | --license-uri           | TEXT      | True (see INFO) | License URI to add to the NFT                                                                            |
+| -m            | --fee                   | TEXT      | False           | Set the fees per transaction, in XCH. [default: 0]                                                       |
+|               | --push / --no-push      | BOOLEAN   | False           | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False           | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False           | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False           | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False           | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False           | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin          | HEXSTRING | False           | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount        | XCH       | False           | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount       | XCH       | False           | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount       | XCH       | False           | Ignore coins worth more than this much XCH or CAT units                                                  |
+|               | --reuse / --new-address | BOOLEAN   | False           | Reuse existing address for the change                                                                    |
+| -h            | --help                  | None      | False           | Show a help message and exit                                                                             |
 
 <details>
 <summary>Example</summary>
@@ -824,14 +824,14 @@ Usage: chia wallet nft set_did [OPTIONS]
 
 Options:
 
-| Short Command | Long Command      | Type    | Required | Description                                                                                              |
-| :------------ | :---------------- | :------ | :------- | :------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
-| -f            | --fingerprint     | INTEGER | False    | Set the fingerprint to specify which wallet to use                                                       |
-| -i            | --id              | INTEGER | True     | Id of the NFT wallet to use                                                                              |
-| -di           | --did-id          | TEXT    | True     | DID Id to set on the NFT                                                                                 |
-| -ni           | --nft-coin-id     | TEXT    | True     | Id of the NFT coin on which to set the DID                                                               |
-| -m            | --fee             | TEXT    | False    | Set the fees per transaction, in XCH. [default: 0]                                                       |
+| Short Command | Long Command            | Type      | Required | Description                                                                                              |
+| :------------ | :---------------------- | :-------- | :------- | :------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port       | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
+| -f            | --fingerprint           | INTEGER   | False    | Set the fingerprint to specify which wallet to use                                                       |
+| -i            | --id                    | INTEGER   | True     | Id of the NFT wallet to use                                                                              |
+| -di           | --did-id                | TEXT      | True     | DID Id to set on the NFT                                                                                 |
+| -ni           | --nft-coin-id           | TEXT      | True     | Id of the NFT coin on which to set the DID                                                               |
+| -m            | --fee                   | TEXT      | False    | Set the fees per transaction, in XCH. [default: 0]                                                       |
 |               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
 |               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
 |               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
@@ -843,7 +843,7 @@ Options:
 | -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
 | -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
 |               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
-| -h            | --help            | None    | False    | Show a help message and exit                                                                             |
+| -h            | --help                  | None      | False    | Show a help message and exit                                                                             |
 
 <details>
 <summary>Example</summary>

--- a/docs/reference-client/cli-reference/offer-cli.md
+++ b/docs/reference-client/cli-reference/offer-cli.md
@@ -48,6 +48,8 @@ Options:
 |               |    --override     |  None   |  False   | Creates offer without checking for unusual values                                                        |
 |               |    --valid-at     | INTEGER |  False   | UNIX timestamp at which the associated transactions become valid                                         |
 |               |   --expires-at    | INTEGER |  False   | UNIX timestamp at which the associated transactions expire                                               |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
 |      -h       |      --help       |  None   |  False   | Show a help message and exit                                                                             |
 
 ---
@@ -67,6 +69,8 @@ Options:
 |      -e       |  --examine-only   |  None   |  False   | Print the summary of the offer file but do not take it                                                   |
 |      -m       |       --fee       |  TEXT   |  False   | The fee to use when pushing the completed offer                                                          |
 |               |      --reuse      |  None   |  False   | Set this flag to reuse an existing address for the offer [Default: generate a new address]               |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
 |      -h       |      --help       |  None   |  False   | Show a help message and exit                                                                             |
 
 ---
@@ -86,6 +90,8 @@ Options:
 |      -id      |       --id        |  TEXT   |   True   | The offer ID that you wish to cancel                                                                                     |
 |               |    --insecure     |  None   |  False   | Set this flag to disable making an on-chain transaction and simply mark the offer as canceled [Default: cancel on-chain] |
 |      -m       |       --fee       |  TEXT   |  False   | The fee to use when canceling the offer securely                                                                         |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                                 |
 |      -h       |      --help       |  None   |  False   | Show a help message and exit                                                                                             |
 
 ---

--- a/docs/reference-client/cli-reference/offer-cli.md
+++ b/docs/reference-client/cli-reference/offer-cli.md
@@ -36,21 +36,21 @@ Usage: `chia wallet make_offer [OPTIONS]`
 
 Options:
 
-| Short Command |   Long Command    |  Type   | Required | Description                                                                                              |
-| :-----------: | :---------------: | :-----: | :------: | :------------------------------------------------------------------------------------------------------- |
-|      -wp      | --wallet-rpc-port | INTEGER |  False   | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
-|      -f       |   --fingerprint   | INTEGER |  False   | Set the fingerprint to specify which wallet to use                                                       |
-|      -o       |      --offer      |  TEXT   |   True   | A wallet id to offer and the amount to offer (formatted like wallet_id:amount)                           |
-|      -r       |     --request     |  TEXT   |   True   | A wallet id of an asset to receive and the amount you wish to receive (formatted like wallet_id:amount)  |
-|      -p       |    --filepath     |  TEXT   |   True   | The path to write the generated offer file to                                                            |
-|      -m       |       --fee       |  TEXT   |  False   | A fee to add to the offer when it gets taken                                                             |
-|               |      --reuse      |  None   |  False   | Set this flag to reuse an existing address for the offer [Default: generate a new address]               |
-|               |    --override     |  None   |  False   | Creates offer without checking for unusual values                                                        |
-|               |    --valid-at     | INTEGER |  False   | UNIX timestamp at which the associated transactions become valid                                         |
-|               |   --expires-at    | INTEGER |  False   | UNIX timestamp at which the associated transactions expire                                               |
-|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
-|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
-|      -h       |      --help       |  None   |  False   | Show a help message and exit                                                                             |
+| Short Command |      Long Command      |  Type   | Required | Description                                                                                              |
+| :-----------: | :--------------------: | :-----: | :------: | :------------------------------------------------------------------------------------------------------- |
+|      -wp      |   --wallet-rpc-port    | INTEGER |  False   | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
+|      -f       |     --fingerprint      | INTEGER |  False   | Set the fingerprint to specify which wallet to use                                                       |
+|      -o       |        --offer         |  TEXT   |   True   | A wallet id to offer and the amount to offer (formatted like wallet_id:amount)                           |
+|      -r       |       --request        |  TEXT   |   True   | A wallet id of an asset to receive and the amount you wish to receive (formatted like wallet_id:amount)  |
+|      -p       |       --filepath       |  TEXT   |   True   | The path to write the generated offer file to                                                            |
+|      -m       |         --fee          |  TEXT   |  False   | A fee to add to the offer when it gets taken                                                             |
+|               |        --reuse         |  None   |  False   | Set this flag to reuse an existing address for the offer [Default: generate a new address]               |
+|               |       --override       |  None   |  False   | Creates offer without checking for unusual values                                                        |
+|               |       --valid-at       | INTEGER |  False   | UNIX timestamp at which the associated transactions become valid                                         |
+|               |      --expires-at      | INTEGER |  False   | UNIX timestamp at which the associated transactions expire                                               |
+|               |   --push / --no-push   | BOOLEAN |  False   | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out |  TEXT   |  False   | A file to write relevant transactions to                                                                 |
+|      -h       |         --help         |  None   |  False   | Show a help message and exit                                                                             |
 
 ---
 
@@ -62,16 +62,16 @@ Usage: `chia wallet take_offer [OPTIONS] PATH_OR_HEX`
 
 Options:
 
-| Short Command |   Long Command    |  Type   | Required | Description                                                                                              |
-| :-----------: | :---------------: | :-----: | :------: | :------------------------------------------------------------------------------------------------------- |
-|      -wp      | --wallet-rpc-port | INTEGER |  False   | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
-|      -f       |   --fingerprint   | INTEGER |  False   | Set the fingerprint to specify which wallet to use                                                       |
-|      -e       |  --examine-only   |  None   |  False   | Print the summary of the offer file but do not take it                                                   |
-|      -m       |       --fee       |  TEXT   |  False   | The fee to use when pushing the completed offer                                                          |
-|               |      --reuse      |  None   |  False   | Set this flag to reuse an existing address for the offer [Default: generate a new address]               |
-|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
-|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
-|      -h       |      --help       |  None   |  False   | Show a help message and exit                                                                             |
+| Short Command |      Long Command      |  Type   | Required | Description                                                                                              |
+| :-----------: | :--------------------: | :-----: | :------: | :------------------------------------------------------------------------------------------------------- |
+|      -wp      |   --wallet-rpc-port    | INTEGER |  False   | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
+|      -f       |     --fingerprint      | INTEGER |  False   | Set the fingerprint to specify which wallet to use                                                       |
+|      -e       |     --examine-only     |  None   |  False   | Print the summary of the offer file but do not take it                                                   |
+|      -m       |         --fee          |  TEXT   |  False   | The fee to use when pushing the completed offer                                                          |
+|               |        --reuse         |  None   |  False   | Set this flag to reuse an existing address for the offer [Default: generate a new address]               |
+|               |   --push / --no-push   | BOOLEAN |  False   | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out |  TEXT   |  False   | A file to write relevant transactions to                                                                 |
+|      -h       |         --help         |  None   |  False   | Show a help message and exit                                                                             |
 
 ---
 
@@ -83,16 +83,16 @@ Usage: `chia wallet cancel_offer [OPTIONS]`
 
 Options:
 
-| Short Command |   Long Command    |  Type   | Required | Description                                                                                                              |
-| :-----------: | :---------------: | :-----: | :------: | :----------------------------------------------------------------------------------------------------------------------- |
-|      -wp      | --wallet-rpc-port | INTEGER |  False   | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml                 |
-|      -f       |   --fingerprint   | INTEGER |  False   | Set the fingerprint to specify which wallet to use                                                                       |
-|      -id      |       --id        |  TEXT   |   True   | The offer ID that you wish to cancel                                                                                     |
-|               |    --insecure     |  None   |  False   | Set this flag to disable making an on-chain transaction and simply mark the offer as canceled [Default: cancel on-chain] |
-|      -m       |       --fee       |  TEXT   |  False   | The fee to use when canceling the offer securely                                                                         |
-|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                                      |
-|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                                 |
-|      -h       |      --help       |  None   |  False   | Show a help message and exit                                                                                             |
+| Short Command |      Long Command      |  Type   | Required | Description                                                                                                              |
+| :-----------: | :--------------------: | :-----: | :------: | :----------------------------------------------------------------------------------------------------------------------- |
+|      -wp      |   --wallet-rpc-port    | INTEGER |  False   | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml                 |
+|      -f       |     --fingerprint      | INTEGER |  False   | Set the fingerprint to specify which wallet to use                                                                       |
+|      -id      |          --id          |  TEXT   |   True   | The offer ID that you wish to cancel                                                                                     |
+|               |       --insecure       |  None   |  False   | Set this flag to disable making an on-chain transaction and simply mark the offer as canceled [Default: cancel on-chain] |
+|      -m       |         --fee          |  TEXT   |  False   | The fee to use when canceling the offer securely                                                                         |
+|               |   --push / --no-push   | BOOLEAN |  False   | Push the transaction to the network [default: push]                                                                      |
+|               | --transaction-file-out |  TEXT   |  False   | A file to write relevant transactions to                                                                                 |
+|      -h       |         --help         |  None   |  False   | Show a help message and exit                                                                                             |
 
 ---
 

--- a/docs/reference-client/cli-reference/vc-cli.md
+++ b/docs/reference-client/cli-reference/vc-cli.md
@@ -156,6 +156,15 @@ Options:
 |               | --push             | None    | False    | Push the transaction to the network [Default: True]                                                      |
 |               | --no-push          | None    | False    | Do not push the transaction to the network [Default: False]                                              |
 |               | --transaction-file | TEXT    | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
+|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
 | -h            | --help             | None    | False    | Show a help message and exit                                                                             |
 
 <details>
@@ -237,6 +246,15 @@ Options:
 |               | --push                 | None    | False    | Push the transaction to the network [Default: True]                                                                                                                         |
 |               | --no-push              | None    | False    | Do not push the transaction to the network [Default: False]                                                                                                                 |
 |               | --transaction-file     | TEXT    | False    | A file to write relevant transactions to                                                                                                                                    |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                                                                                            |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                                                                                                  |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                                                                                              |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                                                                                               |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                                                                                          |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                                                                                           |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                                                                                     |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                                                                                     |
+|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                                                                                       |
 | -h            | --help                 | None    | False    | Show a help message and exit                                                                                                                                                |
 
 <details>
@@ -306,6 +324,15 @@ Options:
 |               | --push                 | None    | False    | Push the transaction to the network [Default: True]                                                                                                                         |
 |               | --no-push              | None    | False    | Do not push the transaction to the network [Default: False]                                                                                                                 |
 |               | --transaction-file     | TEXT    | False    | A file to write relevant transactions to                                                                                                                                    |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                                                                                            |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                                                                                                  |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                                                                                              |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                                                                                               |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                                                                                          |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                                                                                           |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                                                                                     |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                                                                                     |
+|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                                                                                       |
 | -h            | --help                 | None    | False    | Show a help message and exit                                                                                                                                                |
 
 <details>

--- a/docs/reference-client/cli-reference/vc-cli.md
+++ b/docs/reference-client/cli-reference/vc-cli.md
@@ -146,16 +146,16 @@ Usage: chia wallet vcs mint [OPTIONS]
 
 Options:
 
-| Short Command | Long Command       | Type    | Required | Description                                                                                              |
-| :------------ | :----------------- | :------ | :------- | :------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port  | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
-| -f            | --fingerprint      | INTEGER | False    | Set the fingerprint to specify which key to use as the issuing wallet                                    |
-| -d            | --did              | TEXT    | True     | The DID of the VC's proof provider. Must be owned by the issuing wallet                                  |
-| -t            | --target-address   | TEXT    | False    | The address to send the VC to once it's minted [Default: send to minting wallet]                         |
-| -m            | --fee              | TEXT    | False    | Blockchain fee for mint transaction, in XCH                                                              |
-|               | --push             | None    | False    | Push the transaction to the network [Default: True]                                                      |
-|               | --no-push          | None    | False    | Do not push the transaction to the network [Default: False]                                              |
-|               | --transaction-file | TEXT    | False    | A file to write relevant transactions to                                                                 |
+| Short Command | Long Command            | Type      | Required | Description                                                                                              |
+| :------------ | :---------------------- | :-------- | :------- | :------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port       | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml |
+| -f            | --fingerprint           | INTEGER   | False    | Set the fingerprint to specify which key to use as the issuing wallet                                    |
+| -d            | --did                   | TEXT      | True     | The DID of the VC's proof provider. Must be owned by the issuing wallet                                  |
+| -t            | --target-address        | TEXT      | False    | The address to send the VC to once it's minted [Default: send to minting wallet]                         |
+| -m            | --fee                   | TEXT      | False    | Blockchain fee for mint transaction, in XCH                                                              |
+|               | --push                  | None      | False    | Push the transaction to the network [Default: True]                                                      |
+|               | --no-push               | None      | False    | Do not push the transaction to the network [Default: False]                                              |
+|               | --transaction-file      | TEXT      | False    | A file to write relevant transactions to                                                                 |
 |               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
 |               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
 |               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
@@ -165,7 +165,7 @@ Options:
 | -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
 | -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
 |               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
-| -h            | --help             | None    | False    | Show a help message and exit                                                                             |
+| -h            | --help                  | None      | False    | Show a help message and exit                                                                             |
 
 <details>
 <summary>Example</summary>
@@ -234,18 +234,18 @@ Usage: chia wallet vcs revoke [OPTIONS]
 
 Options:
 
-| Short Command | Long Command           | Type    | Required | Description                                                                                                                                                                 |
-| :------------ | :--------------------- | :------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port      | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml                                                                    |
-| -f            | --fingerprint          | INTEGER | False    | Set the fingerprint to specify which key to use                                                                                                                             |
-| -p            | --parent-coin-id       | TEXT    | True\*   | The ID of the parent coin of the VC (\*optional if VC ID is used)                                                                                                           |
-| -l            | --vc-id TEXT           | TEXT    | True\*   | The launcher ID of the VC to revoke (must be tracked by wallet) (\*optional if Parent ID is used)                                                                           |
-| -m            | --fee                  | TEXT    | False    | Blockchain fee for revocation transaction, in XCH                                                                                                                           |
-|               | --reuse-puzhash        | None    | False    | If this flag is set, then send the VC back to the same puzzle hash it came from (ignored if `--generate-new-puzhash` is also specified) [Default: generate new puzzle hash] |
-|               | --generate-new-puzhash | None    | False    | If this flag is set, then send the VC to a new puzzle hash. This is the default behavior, and setting this flag will override the `--reuse-puzhash` flag if it is also set  |
-|               | --push                 | None    | False    | Push the transaction to the network [Default: True]                                                                                                                         |
-|               | --no-push              | None    | False    | Do not push the transaction to the network [Default: False]                                                                                                                 |
-|               | --transaction-file     | TEXT    | False    | A file to write relevant transactions to                                                                                                                                    |
+| Short Command | Long Command            | Type      | Required | Description                                                                                                                                                                 |
+| :------------ | :---------------------- | :-------- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port       | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml                                                                    |
+| -f            | --fingerprint           | INTEGER   | False    | Set the fingerprint to specify which key to use                                                                                                                             |
+| -p            | --parent-coin-id        | TEXT      | True\*   | The ID of the parent coin of the VC (\*optional if VC ID is used)                                                                                                           |
+| -l            | --vc-id TEXT            | TEXT      | True\*   | The launcher ID of the VC to revoke (must be tracked by wallet) (\*optional if Parent ID is used)                                                                           |
+| -m            | --fee                   | TEXT      | False    | Blockchain fee for revocation transaction, in XCH                                                                                                                           |
+|               | --reuse-puzhash         | None      | False    | If this flag is set, then send the VC back to the same puzzle hash it came from (ignored if `--generate-new-puzhash` is also specified) [Default: generate new puzzle hash] |
+|               | --generate-new-puzhash  | None      | False    | If this flag is set, then send the VC to a new puzzle hash. This is the default behavior, and setting this flag will override the `--reuse-puzhash` flag if it is also set  |
+|               | --push                  | None      | False    | Push the transaction to the network [Default: True]                                                                                                                         |
+|               | --no-push               | None      | False    | Do not push the transaction to the network [Default: False]                                                                                                                 |
+|               | --transaction-file      | TEXT      | False    | A file to write relevant transactions to                                                                                                                                    |
 |               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                                                                                            |
 |               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                                                                                                  |
 |               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                                                                                              |
@@ -255,7 +255,7 @@ Options:
 | -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                                                                                     |
 | -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                                                                                     |
 |               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                                                                                       |
-| -h            | --help                 | None    | False    | Show a help message and exit                                                                                                                                                |
+| -h            | --help                  | None      | False    | Show a help message and exit                                                                                                                                                |
 
 <details>
 <summary>Example</summary>
@@ -311,19 +311,19 @@ Usage: chia wallet vcs update_proofs [OPTIONS]
 
 Options:
 
-| Short Command | Long Command           | Type    | Required | Description                                                                                                                                                                 |
-| :------------ | :--------------------- | :------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port      | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml                                                                    |
-| -f            | --fingerprint          | INTEGER | False    | Set the fingerprint to specify which key to use                                                                                                                             |
-| -l            | --vc-id                | TEXT    | True     | The launcher ID of the VC whose proofs should be updated                                                                                                                    |
-| -t            | --new-puzhash          | TEXT    | False    | The puzzle hash to which to send the VC after the proofs have been updated                                                                                                  |
-| -p            | --new-proof-hash       | TEXT    | True     | The new proof hash to update the VC to                                                                                                                                      |
-| -m            | --fee                  | TEXT    | False    | Blockchain fee for update transaction, in XCH                                                                                                                               |
-|               | --reuse-puzhash        | None    | False    | If this flag is set, then send the VC back to the same puzzle hash it came from (ignored if `--generate-new-puzhash` is also specified) [Default: generate new puzzle hash] |
-|               | --generate-new-puzhash | None    | False    | If this flag is set, then send the VC to a new puzzle hash. This is the default behavior, and setting this flag will override the `--reuse-puzhash` flag if it is also set  |
-|               | --push                 | None    | False    | Push the transaction to the network [Default: True]                                                                                                                         |
-|               | --no-push              | None    | False    | Do not push the transaction to the network [Default: False]                                                                                                                 |
-|               | --transaction-file     | TEXT    | False    | A file to write relevant transactions to                                                                                                                                    |
+| Short Command | Long Command            | Type      | Required | Description                                                                                                                                                                 |
+| :------------ | :---------------------- | :-------- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port       | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml                                                                    |
+| -f            | --fingerprint           | INTEGER   | False    | Set the fingerprint to specify which key to use                                                                                                                             |
+| -l            | --vc-id                 | TEXT      | True     | The launcher ID of the VC whose proofs should be updated                                                                                                                    |
+| -t            | --new-puzhash           | TEXT      | False    | The puzzle hash to which to send the VC after the proofs have been updated                                                                                                  |
+| -p            | --new-proof-hash        | TEXT      | True     | The new proof hash to update the VC to                                                                                                                                      |
+| -m            | --fee                   | TEXT      | False    | Blockchain fee for update transaction, in XCH                                                                                                                               |
+|               | --reuse-puzhash         | None      | False    | If this flag is set, then send the VC back to the same puzzle hash it came from (ignored if `--generate-new-puzhash` is also specified) [Default: generate new puzzle hash] |
+|               | --generate-new-puzhash  | None      | False    | If this flag is set, then send the VC to a new puzzle hash. This is the default behavior, and setting this flag will override the `--reuse-puzhash` flag if it is also set  |
+|               | --push                  | None      | False    | Push the transaction to the network [Default: True]                                                                                                                         |
+|               | --no-push               | None      | False    | Do not push the transaction to the network [Default: False]                                                                                                                 |
+|               | --transaction-file      | TEXT      | False    | A file to write relevant transactions to                                                                                                                                    |
 |               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                                                                                            |
 |               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                                                                                                  |
 |               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                                                                                              |
@@ -333,7 +333,7 @@ Options:
 | -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                                                                                     |
 | -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                                                                                     |
 |               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                                                                                       |
-| -h            | --help                 | None    | False    | Show a help message and exit                                                                                                                                                |
+| -h            | --help                  | None      | False    | Show a help message and exit                                                                                                                                                |
 
 <details>
 <summary>Example</summary>

--- a/docs/reference-client/cli-reference/wallet-cli.md
+++ b/docs/reference-client/cli-reference/wallet-cli.md
@@ -1069,6 +1069,17 @@ Options:
 | -f            | --fingerprint     | INTEGER | False    | Set the fingerprint to specify which wallet to use                                                           |
 | -ids          | --tx_ids          | TEXT    | True     | IDs of the Clawback transactions you want to revert or claim. Separate multiple IDs by comma (,)             |
 | -m            | --fee             | TEXT    | False    | A fee to add to the offer when it gets taken, in XCH [default: 0]                                            |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
+|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
 | -h            | --help            | None    | False    | Show a help message and exit                                                                                 |
 
 Note that wallet will automatically detect whether the transactions should be reverted (clawed back) or claimed.
@@ -1606,6 +1617,12 @@ Options:
 | -a            | --amount          | TEXT    | False    | The amount (in XCH) to send to get the notification past the recipient's spam filter [default: 0.00001]      |
 | -n            | --message         | TEXT    | True     | The message of the notification                                                                              |
 | -m            | --fee             | TEXT    | False    | The fee for the transaction                                                                                  |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
 | -h            | --help            | None    | False    | Show a help message and exit                                                                                 |
 
 <details>
@@ -1650,6 +1667,13 @@ Options:
 |               | --exclude-coin    | TEXT    | False    | Exclude this coin from being spent                                                                           |
 |               | --reuse           | None    | False    | Set this flag to reuse an existing address for the change [default: not set]                                 |
 |               | --clawback_time   | INTEGER | False    | The seconds that the recipient needs to wait to claim the fund. A positive number will enable this feature   |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
+|               | --exclude-amount  | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
 | -h            | --help            | None    | False    | Show a help message and exit                                                                                 |
 
 <details>

--- a/docs/reference-client/cli-reference/wallet-cli.md
+++ b/docs/reference-client/cli-reference/wallet-cli.md
@@ -1062,25 +1062,25 @@ Usage: chia wallet delete_unconfirmed_transactions [OPTIONS]
 
 Options:
 
-| Short Command | Long Command      | Type    | Required | Description                                                                                                  |
-| :------------ | :---------------- | :------ | :------- | :----------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the `rpc_port` under `wallet` in config.yaml |
-| -i            | --id              | INTEGER | False    | ID of the wallet to use [default: 1]                                                                         |
-| -f            | --fingerprint     | INTEGER | False    | Set the fingerprint to specify which wallet to use                                                           |
-| -ids          | --tx_ids          | TEXT    | True     | IDs of the Clawback transactions you want to revert or claim. Separate multiple IDs by comma (,)             |
-| -m            | --fee             | TEXT    | False    | A fee to add to the offer when it gets taken, in XCH [default: 0]                                            |
-|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
-|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
-|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
-|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
-|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
-|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
-|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                       |
-|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
-| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                  |
-| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                  |
-|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                    |
-| -h            | --help            | None    | False    | Show a help message and exit                                                                                 |
+| Short Command | Long Command            | Type      | Required | Description                                                                                                  |
+| :------------ | :---------------------- | :-------- | :------- | :----------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port       | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the `rpc_port` under `wallet` in config.yaml |
+| -i            | --id                    | INTEGER   | False    | ID of the wallet to use [default: 1]                                                                         |
+| -f            | --fingerprint           | INTEGER   | False    | Set the fingerprint to specify which wallet to use                                                           |
+| -ids          | --tx_ids                | TEXT      | True     | IDs of the Clawback transactions you want to revert or claim. Separate multiple IDs by comma (,)             |
+| -m            | --fee                   | TEXT      | False    | A fee to add to the offer when it gets taken, in XCH [default: 0]                                            |
+|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                          |
+|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                     |
+|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                             |
+|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                                   |
+|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                               |
+|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                                |
+|               | --exclude-coin          | HEXSTRING | False    | Exclude this coin from being spent                                                                           |
+|               | --exclude-amount        | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                            |
+| -ma           | --min-coin-amount       | XCH       | False    | Ignore coins worth less than this much XCH or CAT units                                                      |
+| -l            | --max-coin-amount       | XCH       | False    | Ignore coins worth more than this much XCH or CAT units                                                      |
+|               | --reuse / --new-address | BOOLEAN   | False    | Reuse existing address for the change                                                                        |
+| -h            | --help                  | None      | False    | Show a help message and exit                                                                                 |
 
 Note that wallet will automatically detect whether the transactions should be reverted (clawed back) or claimed.
 
@@ -1609,21 +1609,21 @@ Usage: chia wallet notifications send [OPTIONS]
 
 Options:
 
-| Short Command | Long Command      | Type    | Required | Description                                                                                                  |
-| :------------ | :---------------- | :------ | :------- | :----------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the `rpc_port` under `wallet` in config.yaml |
-| -f            | --fingerprint     | INTEGER | False    | Set the fingerprint to specify which wallet to use                                                           |
-| -t            | --to-address      | TEXT    | True     | The address to send the notification to                                                                      |
-| -a            | --amount          | TEXT    | False    | The amount (in XCH) to send to get the notification past the recipient's spam filter [default: 0.00001]      |
-| -n            | --message         | TEXT    | True     | The message of the notification                                                                              |
-| -m            | --fee             | TEXT    | False    | The fee for the transaction                                                                                  |
-|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
-|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
-|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
-|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
-|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
-|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
-| -h            | --help            | None    | False    | Show a help message and exit                                                                                 |
+| Short Command | Long Command           | Type      | Required | Description                                                                                                  |
+| :------------ | :--------------------- | :-------- | :------- | :----------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port      | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the `rpc_port` under `wallet` in config.yaml |
+| -f            | --fingerprint          | INTEGER   | False    | Set the fingerprint to specify which wallet to use                                                           |
+| -t            | --to-address           | TEXT      | True     | The address to send the notification to                                                                      |
+| -a            | --amount               | TEXT      | False    | The amount (in XCH) to send to get the notification past the recipient's spam filter [default: 0.00001]      |
+| -n            | --message              | TEXT      | True     | The message of the notification                                                                              |
+| -m            | --fee                  | TEXT      | False    | The fee for the transaction                                                                                  |
+|               | --push / --no-push     | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                          |
+|               | --transaction-file-out | TEXT      | False    | A file to write relevant transactions to                                                                     |
+|               | --valid-at             | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                             |
+|               | --expires-at           | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                                   |
+|               | --include-coin         | HEXSTRING | False    | Include this coin in the spend                                                                               |
+|               | --primary-coin         | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                                |
+| -h            | --help                 | None      | False    | Show a help message and exit                                                                                 |
 
 <details>
 <summary>Example</summary>
@@ -1652,29 +1652,29 @@ Usage: chia wallet send [OPTIONS]
 
 Options:
 
-| Short Command | Long Command      | Type    | Required | Description                                                                                                  |
-| :------------ | :---------------- | :------ | :------- | :----------------------------------------------------------------------------------------------------------- |
-| -wp           | --wallet-rpc-port | INTEGER | False    | Set the port where the Wallet is hosting the RPC interface. See the `rpc_port` under `wallet` in config.yaml |
-| -f            | --fingerprint     | INTEGER | False    | Set the fingerprint to specify which wallet to use                                                           |
-| -i            | --id              | INTEGER | False    | ID of the wallet to use [default: 1]                                                                         |
-| -a            | --amount          | TEXT    | True     | How much chia to send, in XCH or CAT units                                                                   |
-| -e            | --memo            | TEXT    | False    | Additional memo for the transaction                                                                          |
-| -m            | --fee             | TEXT    | False    | Set the fees for the transaction, in XCH [default: 0]                                                        |
-| -t            | --address         | TEXT    | True     | Address to send the XCH                                                                                      |
-| -o            | --override        | None    | False    | Submits transaction without checking for unusual values [default: disabled]                                  |
-| -ma           | --min-coin-amount | TEXT    | False    | Ignore coins worth less then this much (XCH or CAT units)                                                    |
-| -l            | --max-coin-amount | TEXT    | False    | Ignore coins worth more then this much (XCH or CAT units)                                                    |
-|               | --exclude-coin    | TEXT    | False    | Exclude this coin from being spent                                                                           |
-|               | --reuse           | None    | False    | Set this flag to reuse an existing address for the change [default: not set]                                 |
-|               | --clawback_time   | INTEGER | False    | The seconds that the recipient needs to wait to claim the fund. A positive number will enable this feature   |
-|               | --push / --no-push      | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                      |
-|               | --transaction-file-out  | TEXT      | False    | A file to write relevant transactions to                                                                 |
-|               | --valid-at              | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                         |
-|               | --expires-at            | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                               |
-|               | --include-coin          | HEXSTRING | False    | Include this coin in the spend                                                                           |
-|               | --primary-coin          | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                            |
-|               | --exclude-amount  | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                        |
-| -h            | --help            | None    | False    | Show a help message and exit                                                                                 |
+| Short Command | Long Command           | Type      | Required | Description                                                                                                  |
+| :------------ | :--------------------- | :-------- | :------- | :----------------------------------------------------------------------------------------------------------- |
+| -wp           | --wallet-rpc-port      | INTEGER   | False    | Set the port where the Wallet is hosting the RPC interface. See the `rpc_port` under `wallet` in config.yaml |
+| -f            | --fingerprint          | INTEGER   | False    | Set the fingerprint to specify which wallet to use                                                           |
+| -i            | --id                   | INTEGER   | False    | ID of the wallet to use [default: 1]                                                                         |
+| -a            | --amount               | TEXT      | True     | How much chia to send, in XCH or CAT units                                                                   |
+| -e            | --memo                 | TEXT      | False    | Additional memo for the transaction                                                                          |
+| -m            | --fee                  | TEXT      | False    | Set the fees for the transaction, in XCH [default: 0]                                                        |
+| -t            | --address              | TEXT      | True     | Address to send the XCH                                                                                      |
+| -o            | --override             | None      | False    | Submits transaction without checking for unusual values [default: disabled]                                  |
+| -ma           | --min-coin-amount      | TEXT      | False    | Ignore coins worth less then this much (XCH or CAT units)                                                    |
+| -l            | --max-coin-amount      | TEXT      | False    | Ignore coins worth more then this much (XCH or CAT units)                                                    |
+|               | --exclude-coin         | TEXT      | False    | Exclude this coin from being spent                                                                           |
+|               | --reuse                | None      | False    | Set this flag to reuse an existing address for the change [default: not set]                                 |
+|               | --clawback_time        | INTEGER   | False    | The seconds that the recipient needs to wait to claim the fund. A positive number will enable this feature   |
+|               | --push / --no-push     | BOOLEAN   | False    | Push the transaction to the network [default: push]                                                          |
+|               | --transaction-file-out | TEXT      | False    | A file to write relevant transactions to                                                                     |
+|               | --valid-at             | INTEGER   | False    | UNIX timestamp at which the associated transactions become valid                                             |
+|               | --expires-at           | INTEGER   | False    | UNIX timestamp at which the associated transactions expire                                                   |
+|               | --include-coin         | HEXSTRING | False    | Include this coin in the spend                                                                               |
+|               | --primary-coin         | HEXSTRING | False    | Use this coin as the primary coin that creates the conditions                                                |
+|               | --exclude-amount       | XCH       | False    | Exclude any coins with this XCH or CAT amount from being included                                            |
+| -h            | --help                 | None      | False    | Show a help message and exit                                                                                 |
 
 <details>
 <summary>Example 1: send with memo</summary>


### PR DESCRIPTION
Adds new common transaction options (`--push/--no-push`, `--transaction-file-out`, `--valid-at`, `--expires-at`, `--include-coin`, `--primary-coin`, coin selection) to all transaction-producing wallet commands. These options were added by the `@chia_command` framework migration in chia-blockchain 2.7.4.

**Files updated:**
- `did-cli.md`: create, update_metadata, message_spend, transfer
- `nft-cli.md`: mint, add_uri, transfer, set_did
- `wallet-cli.md`: send, clawback, notifications send
- `offer-cli.md`: make_offer, take_offer, cancel_offer
- `vc-cli.md`: mint, update_proofs, revoke

No existing options were changed or removed — all changes are additive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to CLI reference markdown; no runtime or API behavior changes.
> 
> **Overview**
> Updates the reference-client CLI docs so transaction-producing **wallet** subcommands match chia-blockchain **2.7.4** after the `@chia_command` framework migration.
> 
> **DID, NFT, offer, VC, and core wallet** command option tables now document the shared flags: `--push` / `--no-push`, `--transaction-file-out`, `--valid-at`, `--expires-at`, coin targeting (`--include-coin`, `--primary-coin`, `--exclude-coin`, `--exclude-amount`), coin bounds (`--min-coin-amount`, `--max-coin-amount`), and in several places `--reuse` / `--new-address`. Offer commands get push and transaction-file options where applicable; VC **mint** / **revoke** / **update_proofs** keep separate `--push` / `--no-push` rows but gain the same timing and coin-selection fields.
> 
> Changes are **additive** only—existing flags and examples are left in place aside from table formatting alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 937dc7dc1e2d33b4bdc47a7a829245f416c6cea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->