### PR TITLE
OABS Update farming-faq.md

### DIFF
--- a/docs/reference-client/troubleshooting/farming-faq.md
+++ b/docs/reference-client/troubleshooting/farming-faq.md
@@ -9,7 +9,7 @@ When you are first operating Chia and wondering if the software is working, here
 
 First off, you'll want to have your configuration set up to do additional logging. The configurations can be found in `config.yaml`. This file is located in `chia/mainnet/config.yaml`.
 
-The location of the `.chia` folder varies, On windows you'll want to look in `C:/Users/your username)/.chia/mainnet/config.yaml`. On Mac, this file is located in `/Users/(your username)/.chia/mainnet/config/config.yaml`.
+The location of the `.chia` folder varies, On windows you'll want to look in `C:/Users/(your username)/.chia/mainnet/config/config.yaml`. On Mac, this file is located in `/Users/(your username)/.chia/mainnet/config/config.yaml`.
 
 Shut down Chia before config access. Open `config.yaml` and edit the first `log_level`, setting it `INFO` instead of `WARNING`. Save the file.
 

--- a/docs/reference-client/troubleshooting/farming-faq.md
+++ b/docs/reference-client/troubleshooting/farming-faq.md
@@ -7,7 +7,7 @@ slug: /reference-client/troubleshooting/farming-faq
 
 When you are first operating Chia and wondering if the software is working, here are some tips to keep you sane.
 
-First off, you'll want to have your configuration set up to do additional logging. The configurations can be found in `config.yaml`. This file is located in `chia/mainnet/config.yaml`.
+First off, you'll want to have your configuration set up to do additional logging. The configurations can be found in `config.yaml`. This file is usually located in `chia/mainnet/config/config.yaml`.
 
 The location of the `.chia` folder varies, On windows you'll want to look in `C:/Users/(your username)/.chia/mainnet/config/config.yaml`. On Mac, this file is located in `/Users/(your username)/.chia/mainnet/config/config.yaml`.
 
@@ -17,7 +17,7 @@ Now, you can relaunch Chia. Give it 20 minutes to run.
 
 Opening the log file while Chia is running, you'll see additional messages. You can find `debug.log` in the `log` directory right next to `config` directory accessed earlier.
 
-Log files are very informative. Once a log fills to 20mb another is created. If there are too many you can delete some of them.
+Log files are very informative. Once a log fills to roughly 50mb another is created. If there are too many you can delete some of them.
 
 Inside what you are looking for are these lines:
 


### PR DESCRIPTION
corrected directory location for config.yaml on windows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or security impact.
> 
> **Overview**
> Updates the **Farming FAQ** troubleshooting doc so `config.yaml` paths match the usual layout under `mainnet/config/config.yaml` (including Windows and Mac examples), adds **“usually”** for the generic path, fixes the Windows username placeholder typo, and changes the described log rollover threshold from **20mb** to **roughly 50mb**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7086d55a1cfc7e91c6f61dae23f316b5be7ab679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->